### PR TITLE
Update CI, documentation, and linter configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,22 @@
 name: build
 on: [push, pull_request]
-jobs:
 
+permissions:
+  contents: read
+
+jobs:
   build:
     name: build
     runs-on: ubuntu-latest
     steps:
 
-    - name: set up go 1.22
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
-      id: go
+    - name: checkout
+      uses: actions/checkout@v6
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+    - name: set up go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.24'
 
     - name: build and test
       run: |
@@ -26,9 +28,9 @@ jobs:
         TZ: America/Chicago
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: v1.58
+        version: v2.7
 
     - name: install goveralls
       run: go install github.com/mattn/goveralls@latest
@@ -46,7 +48,7 @@ jobs:
         docker push radiot/stream-recorder:master
 
     - name: build and push tagged image
-      if: github.event_name == 'push' && github.event.ref_type == 'tag'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       run: |
         GIT_TAG="${GITHUB_REF#refs/tags/}"
         docker build -t radiot/stream-recorder:${GIT_TAG} .
@@ -54,9 +56,3 @@ jobs:
         docker push radiot/stream-recorder:${GIT_TAG}
         docker tag radiot/stream-recorder:${GIT_TAG} radiot/stream-recorder:latest
         docker push radiot/stream-recorder:latest
-
-#    - name: remote deployment from master
-#      if: ${{ github.ref == 'refs/heads/master' }}
-#      env:
-#        UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-#      run: curl https://radio-t.com/updater/update/stream-recorder/${UPDATER_KEY}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,95 +1,87 @@
+version: "2"
+
 run:
   concurrency: 4
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m
 
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
-
-  # include test files or not, default is true
-  tests: true
-
-
 linters:
-  enable-all: false
-  disable:
-  - unused
-  - exhaustivestruct    # [deprecated]: Checks if all struct's fields are initialized [fast: false, auto-fix: false]
-  - godot               # : Check if comments end in a period [fast: true, auto-fix: true]
-  - godox               # : Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
-  - golint              # [deprecated]: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: false, auto-fix: false]
-  - ifshort             # [deprecated]: Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
-  - interfacer          # [deprecated]: Linter that suggests narrower interface types [fast: false, auto-fix: false]
-  - ireturn             # : Accept Interfaces, Return Concrete Types [fast: true, auto-fix: false]
-  - lll                 # : Reports long lines [fast: true, auto-fix: false]
-  - maligned            # [deprecated]: Tool to detect Go structs that would take less memory if their fields were sorted [fast: false, auto-fix: false]
-  - nlreturn            # : Nlreturn checks for a new line before return and branch statements to increase code clarity.
-  - nosnakecase         # [deprecated]: Checks that no snake_case names are used [fast: true, auto-fix: false]
-  - paralleltest        # : paralleltest detects missing usage of t.Parallel() method in your Go test [fast: true, auto-fix: false]
-  - scopelint           # [deprecated]: Scopelint checks for unpinned variables in go programs [fast: false, auto-fix: false]
-  - unused         # [deprecated]: Finds unused struct fields [fast: false, auto-fix: false]
-  - unused            # [deprecated]: Finds unused global variables and constants [fast: false, auto-fix: false]
-  - varnamelen          #: checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
-  - wsl                 # : Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
-
-# output configuration options
-output:
-  # print lines of code with issue, default is true
-  print-issued-lines: false
-
-  # sorts results by: filepath, line and column
-  sort-results: true
-
-# all available settings of specific linters
-linters-settings:
-  gocritic:
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint run` to see all tags and checks.
-    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
-    enabled-tags:
-    - diagnostic
-    - experimental
-    - opinionated
-    - performance
-    - style
-    disabled-checks:
-    - whyNoLint
-
-  gocyclo:
-    # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 10
-
-  gci:
-    sections:
-    - standard   # Standard section: captures all standard packages.
-    - default   # Default section: contains all imports that could not be matched to another section type.
-    - prefix(github.com/radio-t/stream-recorder)   # Custom section: groups all imports with the specified Prefix.
-    - blank   # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
-    - dot   # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
-    skip-generated: false
-    custom-order: true
-
-  tagalign:
-    order:
-    - validate
-    - koanf
-    - json
-    - yaml
-    - yml
-    - toml
-    - enums
-    - mapstructure
-    - binding
-    - example
-
-issues:
-  exclude-rules:
-  - path: (.+)_test.go
-    linters:
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - copyloopvar
+    - exhaustive
     - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - goheader
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - nestif
+    - noctx
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - staticcheck
+    - testifylint
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
     - exhaustruct
-  exclude-dirs:
-  - vendor
-  exclude-files:
-  - (.+)moq_test.go
-  exclude-use-default: false
+    - tagliatelle
+    - revive
+
+  settings:
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - whyNoLint
+
+    gocyclo:
+      min-complexity: 10
+
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - funlen
+          - exhaustruct
+    paths:
+      - vendor
+      - '.*moq_test\.go$'
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/radio-t/stream-recorder)
+        - blank
+        - dot
+      custom-order: true

--- a/README.md
+++ b/README.md
@@ -1,45 +1,38 @@
 # Stream Recorder
 
-stream-recorder is used to listen and record audio stream when it is available(every 5 seconds),
-save as episodes in provided directory and naming them after calling site api.
+[![build](https://github.com/radio-t/stream-recorder/actions/workflows/ci.yml/badge.svg)](https://github.com/radio-t/stream-recorder/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/radio-t/stream-recorder/badge.svg?branch=master)](https://coveralls.io/github/radio-t/stream-recorder?branch=master)
+
+Stream-recorder listens and records audio stream when it is available, saving episodes to a directory with names derived from the Radio-t API.
 
 ## Usage
-```
-stream-recorder is used to listen and record audio stream when it is available,
-save as episodes in provided directory and naming them after calling site api
-
-Options:
-  -dir string
-        Recording directory (default "./")
-  -port string
-        If provided app will start REST API server on the port otherwise server is disabled
-  -site string
-        Radio-t API (default "https://radio-t.com/site-api/last/1")
-  -stream string
-        Stream url (default "https://stream.radio-t.com")
-```
-
-## Example:
 
 ```
+Application Options:
+  -s, --stream= Stream url (default: https://stream.radio-t.com) [$STREAM]
+      --site=   Radio-t API (default: https://radio-t.com/site-api/last/1) [$SITE]
+  -d, --dir=    Recording directory (default: ./) [$DIR]
+  -p, --port=   If provided will start API server on the port otherwise server is disabled [$PORT]
+```
+
+## Example
+
+```bash
 make build
 ./streamrecorder --stream 'https://stream.radio-t.com' --port 8080 --dir ./records
 ```
 
-## Using Docker
-Run using docker compose
+## Docker
+
 ```bash
 docker-compose up --detach
 ```
 
-## Options
+## API Endpoints
 
-### `port`
-HTTP Server option allows the stream-recorder to run a server for trying out the REST API on a specified port. The server will serve the following endpoints:
-- `/download/<record>`: to download an episode
-- `/health`: to check the application's health, warning if disk capacity exceeds 80%
-- `/records`: to view recorded episodes
-- `/`: provides a Swagger UI for easier interaction with the API.
+When `--port` is provided, the server exposes:
 
-### `site`
-By default with fetch [Radio-t API]("https://radio-t.com/site-api/last/1") recieving data on the latest episode
+- `/` - web UI listing recorded episodes
+- `/health` - health check endpoint (warns if disk capacity exceeds 80%)
+- `/episode/<name>` - download entire episode as ZIP archive
+- `/record/<path>` - download individual MP3 file

--- a/app/main.go
+++ b/app/main.go
@@ -70,7 +70,7 @@ func main() {
 }
 
 func run(ctx context.Context, l *recorder.Listener, r *recorder.Recorder) {
-	ticker := time.NewTicker(time.Second * 5) //nolint:gomnd
+	ticker := time.NewTicker(time.Second * 5) //nolint:mnd
 	defer ticker.Stop()
 	for {
 		select {

--- a/app/recorder/listener.go
+++ b/app/recorder/listener.go
@@ -29,7 +29,7 @@ func NewListener(c Clientlike) *Listener {
 
 func getStreamNumber(latest string) string {
 	args := strings.Split(latest, " ")
-	if len(args) < 2 { //nolint:gomnd
+	if len(args) < 2 { //nolint:mnd
 		return "0"
 	}
 	return args[1]

--- a/app/recorder/listener_test.go
+++ b/app/recorder/listener_test.go
@@ -2,7 +2,6 @@ package recorder_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -44,6 +43,7 @@ func TestListener(t *testing.T) {
 					return nil, recorder.ErrNotFound
 				},
 			},
+			expected:  "",
 			errorFunc: assert.Error,
 		},
 	}
@@ -70,7 +70,7 @@ func TestListener(t *testing.T) {
 
 			got := string(buf)
 
-			assert.Equal(t, tc.expected, got, fmt.Sprintf(`expected stream of: %q but got: %q`, tc.expected, got))
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/app/recorder/models.go
+++ b/app/recorder/models.go
@@ -3,8 +3,6 @@ package recorder
 import "time"
 
 // Entry API сайта radio-t.com https://radio-t.com/api-docs/
-//
-//nolint:tagliatelle
 type Entry struct {
 	URL        string      `json:"url"`                   // url поста
 	Title      string      `json:"title"`                 // заголовок поста

--- a/app/recorder/recorder.go
+++ b/app/recorder/recorder.go
@@ -30,7 +30,7 @@ func (r *Recorder) prepareFile(episode string) (*os.File, error) {
 
 	_, err := os.Stat(fileDir)
 	if os.IsNotExist(err) {
-		err = os.MkdirAll(fileDir, os.ModePerm)
+		err = os.MkdirAll(fileDir, 0o750)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s directory: %w", fileDir, err)

--- a/app/server/health.go
+++ b/app/server/health.go
@@ -53,11 +53,11 @@ func (s *Server) getCapacity() (int, error) {
 		return 0, fmt.Errorf("failed to make Statfs call: %w, path: %s", err, s.dir)
 	}
 
-	total := stats.Blocks * uint64(stats.Bsize)
-	free := stats.Bfree * uint64(stats.Bsize)
+	total := stats.Blocks * uint64(stats.Bsize) //nolint:gosec,nolintlint // bsize is always positive
+	free := stats.Bfree * uint64(stats.Bsize)   //nolint:gosec,nolintlint // bsize is always positive
 	used := total - free
 
-	capacity := int(used * 100 / total)
+	capacity := int(used * 100 / total) //nolint:gosec // overflow is not possible here
 
 	return capacity, nil
 }

--- a/app/server/index.go
+++ b/app/server/index.go
@@ -24,13 +24,13 @@ func newIndex(p string) (*index, error) {
 
 	dirs, err := os.ReadDir(p)
 	if err != nil {
-		return &index{}, fmt.Errorf("error reading main dir, %w", err) //nolint:exhaustruct
+		return nil, fmt.Errorf("error reading main dir, %w", err)
 	}
 
 	for _, dir := range dirs {
 		e, err := os.ReadDir(path.Join(p, dir.Name()))
 		if err != nil {
-			return &index{}, fmt.Errorf("error reading episode dir, %w", err) //nolint:exhaustruct
+			return nil, fmt.Errorf("error reading episode dir, %w", err)
 		}
 		for _, file := range e {
 			i.addEpisode(dir.Name(), path.Join(dir.Name(), file.Name()))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/radio-t/stream-recorder
 
-go 1.22
+go 1.24
 
 require (
 	github.com/jessevdk/go-flags v1.6.1
@@ -12,5 +12,4 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-
 )


### PR DESCRIPTION
## Summary

- Bump Go version from 1.22 to 1.24
- Update all GitHub Actions to latest versions:
  - `actions/checkout@v4` → `actions/checkout@v6`
  - `actions/setup-go@v5` → `actions/setup-go@v6`
  - `golangci/golangci-lint-action@v6` → `golangci/golangci-lint-action@v9`
- Fix GitHub Actions workflow:
  - Reorder checkout before setup-go for proper Go module caching
  - Add `permissions: contents: read` block for GITHUB_TOKEN
  - Update golangci-lint from v1.58 to v2.7
  - Fix tagged image condition (`startsWith(github.ref, 'refs/tags/')` instead of `github.event.ref_type == 'tag'`)
- Update golangci-lint config to v2 format (new exclusions structure, removed deprecated options)
- Fix README: remove incorrect Swagger UI references, update endpoint documentation, add badges
- Fix various linter issues (gosec, exhaustruct, nolintlint, testifylint)
- Update nolint directives from deprecated `gomnd` to `mnd`