### PR TITLE
Add schedule-aware logging and recording window badge

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -77,7 +78,7 @@ func main() {
 	listener := recorder.NewListener(client)
 
 	wg := sync.WaitGroup{}
-	startServer(ctx, &wg, opts.Port, opts.Dir, opts.AuthPasswd, &forceRecord, &recording)
+	startServer(ctx, &wg, opts.Port, opts.Dir, opts.AuthPasswd, &forceRecord, &recording, makeScheduleStatusFn(opts.Schedule))
 	startPurge(ctx, &wg, purgeConfig{
 		dir:           opts.Dir,
 		retentionDays: opts.RetentionDays,
@@ -86,7 +87,7 @@ func main() {
 	})
 
 	cfg := newRunConfig(opts.Schedule, opts.NewsAPI)
-	state := &recordingState{forceRecord: &forceRecord, recording: &recording}
+	state := &recordingState{forceRecord: &forceRecord, recording: &recording} //nolint:exhaustruct // wasInWindow, pollCount start at zero
 
 	wg.Add(1)
 	go func() {
@@ -126,6 +127,8 @@ type runConfig struct {
 type recordingState struct {
 	forceRecord *atomic.Bool
 	recording   *atomic.Bool
+	wasInWindow bool // tracks previous window state for transition logging
+	pollCount   int  // counts polls within current state for throttled debug logging
 }
 
 // newRunConfig creates a runConfig with standard defaults, optionally enabling chapter tracking.
@@ -147,13 +150,14 @@ func newRunConfig(schedule bool, newsAPI string) runConfig {
 }
 
 // startServer starts the HTTP server if a port is configured.
-func startServer(ctx context.Context, wg *sync.WaitGroup, port, dir, authPasswd string, forceRecord, recording *atomic.Bool) {
+func startServer(ctx context.Context, wg *sync.WaitGroup, port, dir, authPasswd string,
+	forceRecord, recording *atomic.Bool, scheduleFn func() server.ScheduleStatus) {
 	if port == "" {
 		return
 	}
 	slog.Info("Healthcheck enabled")
 
-	s := server.NewServer(port, dir, authPasswd, forceRecord, recording)
+	s := server.NewServer(port, dir, authPasswd, forceRecord, recording, scheduleFn)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -249,6 +253,78 @@ func inScheduleWindow(now time.Time) bool {
 	return nowHour >= startHour || nowHour < endHour
 }
 
+// timeToShow returns the duration until the show starts (Saturday showHour UTC).
+// returns 0 if the show has already started or it's not Saturday.
+func timeToShow(now time.Time) time.Duration {
+	now = now.UTC()
+	if now.Weekday() != showDay {
+		return 0
+	}
+	showStart := time.Date(now.Year(), now.Month(), now.Day(), showHour, 0, 0, 0, time.UTC)
+	if !showStart.After(now) {
+		return 0
+	}
+	return showStart.Sub(now)
+}
+
+// timeToNextWindow returns the duration until the next recording window opens.
+func timeToNextWindow(now time.Time) time.Duration {
+	now = now.UTC()
+	windowStartHour := showHour - showBeforeHours
+	daysUntilSat := int((showDay - now.Weekday() + 7) % 7)
+	windowStart := time.Date(now.Year(), now.Month(), now.Day()+daysUntilSat, windowStartHour, 0, 0, 0, time.UTC)
+	if !windowStart.After(now) {
+		windowStart = windowStart.AddDate(0, 0, 7)
+	}
+	return windowStart.Sub(now)
+}
+
+// fmtDuration formats a duration as a human-readable string like "1h32m" or "45m".
+func fmtDuration(d time.Duration) string {
+	d = d.Truncate(time.Minute)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60 //nolint:mnd
+	if h > 0 {
+		return fmt.Sprintf("%dh%02dm", h, m)
+	}
+	return fmt.Sprintf("%dm", m)
+}
+
+// fmtBytes formats a byte count as a human-readable string.
+func fmtBytes(b int64) string {
+	const (
+		mb = 1024 * 1024
+		gb = 1024 * 1024 * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1fGB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1fMB", float64(b)/float64(mb))
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}
+
+// makeScheduleStatusFn returns a function for the server to query schedule window status.
+// returns nil when schedule is disabled.
+func makeScheduleStatusFn(schedule bool) func() server.ScheduleStatus {
+	if !schedule {
+		return nil
+	}
+	return func() server.ScheduleStatus {
+		now := time.Now()
+		if !inScheduleWindow(now) {
+			return server.ScheduleStatus{} //nolint:exhaustruct // zero value means outside window
+		}
+		status := "show in progress"
+		if ttShow := timeToShow(now); ttShow > 0 {
+			status = fmtDuration(ttShow) + " to show"
+		}
+		return server.ScheduleStatus{InWindow: true, ShowStatus: status}
+	}
+}
+
 // loopAction indicates whether the recording loop should continue or stop.
 type loopAction bool
 
@@ -273,23 +349,59 @@ func run(ctx context.Context, l streamListener, r streamRecorder, cfg runConfig,
 	}
 }
 
+// debugLogInterval controls how often repetitive debug messages are emitted (every N polls).
+// with a 5s tick interval this means debug messages appear roughly every minute.
+const debugLogInterval = 12
+
+// logWindowTransitions detects and logs recording window entry/exit transitions.
+// returns whether the current time is inside the recording window.
+func logWindowTransitions(cfg runConfig, state *recordingState) bool {
+	inWindow := !cfg.schedule || inScheduleWindow(cfg.nowFn())
+	if !cfg.schedule {
+		return inWindow
+	}
+
+	if inWindow && !state.wasInWindow {
+		state.pollCount = 0
+		if ttShow := timeToShow(cfg.nowFn()); ttShow > 0 {
+			slog.Info("entered recording window", slog.String("show_in", fmtDuration(ttShow)))
+		} else {
+			slog.Info("entered recording window, show in progress")
+		}
+	} else if !inWindow && state.wasInWindow {
+		state.pollCount = 0
+		slog.Info("exited recording window")
+	}
+	state.wasInWindow = inWindow
+	return inWindow
+}
+
 // pollAndRecord checks the schedule, listens for a stream and records it.
 // returns stopLoop when the context is cancelled and the loop should exit.
 func pollAndRecord(ctx context.Context, l streamListener, r streamRecorder, cfg runConfig, state *recordingState) loopAction {
 	forced := state.forceRecord != nil && state.forceRecord.Load()
-	if !forced && cfg.schedule && !inScheduleWindow(cfg.nowFn()) {
-		slog.Debug("outside recording window")
+	inWindow := logWindowTransitions(cfg, state)
+
+	if !forced && !inWindow {
+		state.pollCount++
+		if state.pollCount == 1 || state.pollCount%debugLogInterval == 0 {
+			slog.Debug("outside recording window", slog.String("next_in", fmtDuration(timeToNextWindow(cfg.nowFn()))))
+		}
 		return continueLoop
 	}
 
 	stream, err := l.Listen(ctx)
 	switch {
 	case errors.Is(err, recorder.ErrNotFound):
-		slog.Debug("stream is not available")
+		state.pollCount++
+		if state.pollCount == 1 || state.pollCount%debugLogInterval == 0 {
+			slog.Debug("waiting for stream", slog.Int("checks", state.pollCount))
+		}
 		return continueLoop
 	case err != nil:
 		slog.Error("error while listening", slog.String("err", err.Error()))
 	default:
+		state.pollCount = 0
 		return recordStream(ctx, r, stream, cfg, state, forced)
 	}
 	return continueLoop
@@ -319,7 +431,9 @@ func recordStream(ctx context.Context, r streamRecorder, stream *recorder.Stream
 		}()
 	}
 
+	startTime := cfg.nowFn()
 	filePath, err := r.Record(ctx, stream)
+	duration := cfg.nowFn().Sub(startTime)
 
 	// stop chapter tracker and wait for it to finish before reading chapters
 	if trackerCancel != nil {
@@ -335,17 +449,31 @@ func recordStream(ctx context.Context, r streamRecorder, stream *recorder.Stream
 
 	if err != nil {
 		if ctx.Err() != nil {
+			logRecordingFinished("recording stopped", stream.Number, filePath, duration)
 			if filePath != "" {
 				maybeInjectChapters(tracker, filePath, cfg.injectChapters)
 			}
 			return stopLoop // clean shutdown
 		}
 		slog.Error("error while recording", slog.String("err", err.Error()))
+		slog.Info("stream lost, waiting for reconnect", slog.String("episode", stream.Number))
 		return continueLoop
 	}
 
+	logRecordingFinished("finished recording", stream.Number, filePath, duration)
 	maybeInjectChapters(tracker, filePath, cfg.injectChapters)
 	return continueLoop
+}
+
+// logRecordingFinished logs a recording completion message with duration and file size.
+func logRecordingFinished(msg, episode, filePath string, duration time.Duration) {
+	attrs := []any{slog.String("episode", episode), slog.String("duration", fmtDuration(duration))}
+	if filePath != "" {
+		if fi, err := os.Stat(filePath); err == nil {
+			attrs = append(attrs, slog.String("size", fmtBytes(fi.Size())))
+		}
+	}
+	slog.Info(msg, attrs...)
 }
 
 // maybeInjectChapters injects collected chapter markers into the recorded file.

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -139,7 +139,7 @@ func TestFullPipeline(t *testing.T) {
 
 	// start server and verify HTTP endpoints
 	port := freePort(t)
-	srv := server.NewServer(strconv.Itoa(port), recordsPath, "", nil, nil)
+	srv := server.NewServer(strconv.Itoa(port), recordsPath, "", nil, nil, nil)
 	go func() { _ = srv.Start() }()
 	defer func() { _ = srv.Stop(context.Background()) }()
 

--- a/app/recorder/recorder.go
+++ b/app/recorder/recorder.go
@@ -136,7 +136,6 @@ func (r *Recorder) Record(ctx context.Context, s *Stream) (string, error) { //no
 			return "", fmt.Errorf("failed to read from stream: %w", readErr)
 		}
 	}
-	slog.Info(fmt.Sprintf("finished recording at %v", time.Now().Format(time.RFC3339)))
 
 	return f.Name(), nil
 }

--- a/app/run_test.go
+++ b/app/run_test.go
@@ -569,6 +569,140 @@ func TestInScheduleWindow(t *testing.T) {
 	}
 }
 
+func TestFmtDuration(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0m"},
+		{30 * time.Second, "0m"},
+		{1 * time.Minute, "1m"},
+		{45 * time.Minute, "45m"},
+		{59 * time.Minute, "59m"},
+		{60 * time.Minute, "1h00m"},
+		{90 * time.Minute, "1h30m"},
+		{2*time.Hour + 15*time.Minute, "2h15m"},
+		{6*time.Hour + 45*time.Minute + 30*time.Second, "6h45m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, fmtDuration(tt.d))
+		})
+	}
+}
+
+func TestFmtBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		b    int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024 * 1024, "1.0MB"},
+		{1536 * 1024, "1.5MB"},
+		{1024 * 1024 * 1024, "1.0GB"},
+		{int64(1.5 * 1024 * 1024 * 1024), "1.5GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, fmtBytes(tt.b))
+		})
+	}
+}
+
+func TestTimeToShow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		now  time.Time
+		want time.Duration
+	}{
+		{"2h before show", time.Date(2026, 3, 28, 18, 0, 0, 0, time.UTC), 2 * time.Hour},
+		{"30m before show", time.Date(2026, 3, 28, 19, 30, 0, 0, time.UTC), 30 * time.Minute},
+		{"at show start", time.Date(2026, 3, 28, 20, 0, 0, 0, time.UTC), 0},
+		{"after show start", time.Date(2026, 3, 28, 21, 0, 0, 0, time.UTC), 0},
+		{"not saturday", time.Date(2026, 3, 30, 18, 0, 0, 0, time.UTC), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, timeToShow(tt.now))
+		})
+	}
+}
+
+func TestTimeToNextWindow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		now  time.Time
+		want time.Duration
+	}{
+		{
+			name: "monday morning",
+			now:  time.Date(2026, 3, 23, 10, 0, 0, 0, time.UTC), // monday 10:00
+			want: 5*24*time.Hour + 8*time.Hour,                  // 5 days + 8h to sat 18:00
+		},
+		{
+			name: "saturday before window",
+			now:  time.Date(2026, 3, 28, 17, 0, 0, 0, time.UTC), // saturday 17:00
+			want: 1 * time.Hour,                                 // 1h to 18:00
+		},
+		{
+			name: "inside window returns next week",
+			now:  time.Date(2026, 3, 28, 19, 0, 0, 0, time.UTC), // saturday 19:00
+			want: 6*24*time.Hour + 23*time.Hour,                 // next sat 18:00
+		},
+		{
+			name: "sunday after window",
+			now:  time.Date(2026, 3, 29, 1, 0, 0, 0, time.UTC), // sunday 01:00
+			want: 6*24*time.Hour + 17*time.Hour,                // next sat 18:00 (6 days + 17h)
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, timeToNextWindow(tt.now))
+		})
+	}
+}
+
+func TestPollAndRecord_WindowTransitionLogging(t *testing.T) {
+	// verify that pollCount resets on window transition and listener is not called outside window
+	ml := &mockStreamListener{
+		listenFn: func(_ context.Context) (*recorder.Stream, error) {
+			return nil, recorder.ErrNotFound
+		},
+	}
+	mr := &mockStreamRecorder{}
+
+	// start outside window (monday), then transition to inside (saturday)
+	currentTime := time.Date(2026, 3, 30, 10, 0, 0, 0, time.UTC) // monday
+	cfg := runConfig{
+		schedule:     true,
+		tickInterval: 10 * time.Millisecond,
+		nowFn:        func() time.Time { return currentTime },
+	}
+	state := &recordingState{}
+
+	// poll outside window
+	pollAndRecord(context.Background(), ml, mr, cfg, state)
+	assert.False(t, state.wasInWindow, "should track that we're outside window")
+	assert.Equal(t, 1, state.pollCount, "poll count should increment outside window")
+	assert.Equal(t, int32(0), ml.calls.Load(), "listener should not be called outside window")
+
+	// transition to inside window
+	currentTime = time.Date(2026, 3, 28, 21, 0, 0, 0, time.UTC) // saturday 21:00
+	pollAndRecord(context.Background(), ml, mr, cfg, state)
+	assert.True(t, state.wasInWindow, "should track that we're inside window")
+	assert.Equal(t, 1, state.pollCount, "poll count should reset on window entry then increment")
+	assert.Equal(t, int32(1), ml.calls.Load(), "listener should be called inside window")
+}
+
 func TestRun_ChapterTrackingPerRecording(t *testing.T) {
 	// verify that a new tracker is created for each recording session
 	var trackerCount atomic.Int32

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -36,37 +36,46 @@ type episode struct {
 	Files []string
 }
 
+// ScheduleStatus represents the current state of the recording window.
+type ScheduleStatus struct {
+	InWindow   bool
+	ShowStatus string // e.g. "32m to show" or "show in progress"
+}
+
 // Server is the main struct for the server
 type Server struct {
-	dir          string
-	srv          *http.Server
-	template     *template.Template
-	warnCapacity int
-	authPasswd   string // bcrypt hash; empty means auth disabled
-	forceRecord  *atomic.Bool
-	recording    *atomic.Bool
-	done         chan struct{}
-	closeOnce    sync.Once
+	dir            string
+	srv            *http.Server
+	template       *template.Template
+	warnCapacity   int
+	authPasswd     string // bcrypt hash; empty means auth disabled
+	forceRecord    *atomic.Bool
+	recording      *atomic.Bool
+	scheduleStatus func() ScheduleStatus // nil when schedule is disabled
+	done           chan struct{}
+	closeOnce      sync.Once
 }
 
 // NewServer creates a new server and sets up handlers.
 // authPasswd is a bcrypt hash; when non-empty, POST /record requires authentication.
 // forceRecord is an optional flag shared with the recording loop; POST /record sets it to true.
 // recording is an optional flag indicating whether a stream is currently being recorded.
-func NewServer(port, dir, authPasswd string, forceRecord, recording *atomic.Bool) *Server {
+// scheduleFn, when non-nil, provides the current recording window status for the UI.
+func NewServer(port, dir, authPasswd string, forceRecord, recording *atomic.Bool, scheduleFn func() ScheduleStatus) *Server {
 	t, err := template.ParseFS(indexTemplateFS, "static/index.html")
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse index template: %v", err))
 	}
 
 	s := Server{ //nolint:exhaustruct
-		dir:          dir,
-		template:     t,
-		warnCapacity: 80, //nolint:mnd
-		authPasswd:   authPasswd,
-		forceRecord:  forceRecord,
-		recording:    recording,
-		done:         make(chan struct{}),
+		dir:            dir,
+		template:       t,
+		warnCapacity:   80, //nolint:mnd
+		authPasswd:     authPasswd,
+		forceRecord:    forceRecord,
+		recording:      recording,
+		scheduleStatus: scheduleFn,
+		done:           make(chan struct{}),
 	}
 
 	router := routegroup.New(http.NewServeMux())
@@ -184,6 +193,11 @@ func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
+	var schedStatus ScheduleStatus
+	if s.scheduleStatus != nil {
+		schedStatus = s.scheduleStatus()
+	}
+
 	data := struct {
 		Episodes        []episode
 		ShowForceRecord bool
@@ -192,6 +206,8 @@ func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		ActiveFile      string
 		ActiveEpisode   string
 		AuthEnabled     bool
+		InWindow        bool
+		ShowStatus      string
 	}{
 		Episodes:        episodes,
 		ShowForceRecord: s.forceRecord != nil,
@@ -200,6 +216,8 @@ func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		ActiveFile:      activeFile,
 		ActiveEpisode:   activeEpisode,
 		AuthEnabled:     s.authPasswd != "",
+		InWindow:        schedStatus.InWindow,
+		ShowStatus:      schedStatus.ShowStatus,
 	}
 
 	var buf bytes.Buffer

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -43,7 +43,7 @@ func setupTestDir(t *testing.T) string {
 
 func newTestServer(t *testing.T, dir string) *Server {
 	t.Helper()
-	return NewServer("0", dir, "", nil, nil)
+	return NewServer("0", dir, "", nil, nil, nil)
 }
 
 func newRequest(t *testing.T, target string) *http.Request {
@@ -119,7 +119,7 @@ func TestIndexHandler(t *testing.T) {
 	t.Run("shows Start Recording button when forceRecord is set", func(t *testing.T) {
 		dir := setupTestDir(t)
 		var flag atomic.Bool
-		srv := NewServer("0", dir, "", &flag, nil)
+		srv := NewServer("0", dir, "", &flag, nil, nil)
 
 		req := newRequest(t, "/")
 		rec := httptest.NewRecorder()
@@ -134,7 +134,7 @@ func TestIndexHandler(t *testing.T) {
 		var forceFlag atomic.Bool
 		var recFlag atomic.Bool
 		recFlag.Store(true)
-		srv := NewServer("0", dir, "", &forceFlag, &recFlag)
+		srv := NewServer("0", dir, "", &forceFlag, &recFlag, nil)
 
 		req := newRequest(t, "/")
 		rec := httptest.NewRecorder()
@@ -149,7 +149,7 @@ func TestIndexHandler(t *testing.T) {
 		dir := setupTestDir(t)
 		var forceFlag atomic.Bool
 		forceFlag.Store(true)
-		srv := NewServer("0", dir, "", &forceFlag, nil)
+		srv := NewServer("0", dir, "", &forceFlag, nil, nil)
 
 		req := newRequest(t, "/")
 		rec := httptest.NewRecorder()
@@ -165,7 +165,7 @@ func TestIndexHandler(t *testing.T) {
 		var flag atomic.Bool
 		hash, hashErr := bcrypt.GenerateFromPassword([]byte("testpass"), bcrypt.MinCost)
 		require.NoError(t, hashErr)
-		srv := NewServer("0", dir, string(hash), &flag, nil)
+		srv := NewServer("0", dir, string(hash), &flag, nil, nil)
 
 		req := newRequest(t, "/")
 		rec := httptest.NewRecorder()
@@ -181,7 +181,7 @@ func TestIndexHandler(t *testing.T) {
 	t.Run("no password field when auth disabled", func(t *testing.T) {
 		dir := setupTestDir(t)
 		var flag atomic.Bool
-		srv := NewServer("0", dir, "", &flag, nil)
+		srv := NewServer("0", dir, "", &flag, nil, nil)
 
 		req := newRequest(t, "/")
 		rec := httptest.NewRecorder()
@@ -201,6 +201,51 @@ func TestIndexHandler(t *testing.T) {
 		rec := serveHTTP(srv, req)
 
 		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("shows schedule badge when in window", func(t *testing.T) {
+		dir := setupTestDir(t)
+		srv := NewServer("0", dir, "", nil, nil, func() ScheduleStatus {
+			return ScheduleStatus{InWindow: true, ShowStatus: "32m to show"}
+		})
+
+		req := newRequest(t, "/")
+		rec := httptest.NewRecorder()
+		srv.IndexHandler(rec, req)
+
+		body := rec.Body.String()
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, body, "LIVE WINDOW")
+		assert.Contains(t, body, "32m to show")
+		assert.Contains(t, body, `content="60"`, "should auto-refresh every 60s when in window")
+	})
+
+	t.Run("hides schedule badge when outside window", func(t *testing.T) {
+		dir := setupTestDir(t)
+		srv := NewServer("0", dir, "", nil, nil, func() ScheduleStatus {
+			return ScheduleStatus{InWindow: false}
+		})
+
+		req := newRequest(t, "/")
+		rec := httptest.NewRecorder()
+		srv.IndexHandler(rec, req)
+
+		body := rec.Body.String()
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NotContains(t, body, "LIVE WINDOW")
+	})
+
+	t.Run("hides schedule badge when schedule disabled", func(t *testing.T) {
+		dir := setupTestDir(t)
+		srv := NewServer("0", dir, "", nil, nil, nil)
+
+		req := newRequest(t, "/")
+		rec := httptest.NewRecorder()
+		srv.IndexHandler(rec, req)
+
+		body := rec.Body.String()
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NotContains(t, body, "LIVE WINDOW")
 	})
 }
 
@@ -332,7 +377,7 @@ func TestForceRecordHandler(t *testing.T) {
 	t.Run("POST /record sets force flag and redirects to index", func(t *testing.T) {
 		dir := t.TempDir()
 		var flag atomic.Bool
-		srv := NewServer("0", dir, "", &flag, nil)
+		srv := NewServer("0", dir, "", &flag, nil, nil)
 
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/record", http.NoBody)
 		require.NoError(t, err)
@@ -345,7 +390,7 @@ func TestForceRecordHandler(t *testing.T) {
 
 	t.Run("route not registered when forceRecord is nil", func(t *testing.T) {
 		dir := t.TempDir()
-		srv := NewServer("0", dir, "", nil, nil)
+		srv := NewServer("0", dir, "", nil, nil, nil)
 
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/record", http.NoBody)
 		require.NoError(t, err)
@@ -434,7 +479,7 @@ func TestCheckAuth(t *testing.T) {
 
 	dir := t.TempDir()
 	var flag atomic.Bool
-	srv := NewServer("0", dir, string(hash), &flag, nil)
+	srv := NewServer("0", dir, string(hash), &flag, nil, nil)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -451,7 +496,7 @@ func TestForceRecordHandler_Auth(t *testing.T) {
 	t.Run("returns 403 without credentials when auth enabled", func(t *testing.T) {
 		dir := t.TempDir()
 		var flag atomic.Bool
-		srv := NewServer("0", dir, string(hash), &flag, nil)
+		srv := NewServer("0", dir, string(hash), &flag, nil, nil)
 
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/record", http.NoBody)
 		require.NoError(t, err)
@@ -464,7 +509,7 @@ func TestForceRecordHandler_Auth(t *testing.T) {
 	t.Run("returns 403 with wrong password when auth enabled", func(t *testing.T) {
 		dir := t.TempDir()
 		var flag atomic.Bool
-		srv := NewServer("0", dir, string(hash), &flag, nil)
+		srv := NewServer("0", dir, string(hash), &flag, nil, nil)
 
 		body := strings.NewReader(url.Values{"password": {"wrong"}}.Encode())
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/record", body)
@@ -479,7 +524,7 @@ func TestForceRecordHandler_Auth(t *testing.T) {
 	t.Run("redirects with correct password via form body", func(t *testing.T) {
 		dir := t.TempDir()
 		var flag atomic.Bool
-		srv := NewServer("0", dir, string(hash), &flag, nil)
+		srv := NewServer("0", dir, string(hash), &flag, nil, nil)
 
 		body := strings.NewReader(url.Values{"password": {"secret123"}}.Encode())
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/record", body)
@@ -495,7 +540,7 @@ func TestForceRecordHandler_Auth(t *testing.T) {
 	t.Run("redirects with correct password via basic auth", func(t *testing.T) {
 		dir := t.TempDir()
 		var flag atomic.Bool
-		srv := NewServer("0", dir, string(hash), &flag, nil)
+		srv := NewServer("0", dir, string(hash), &flag, nil, nil)
 
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/record", http.NoBody)
 		require.NoError(t, err)
@@ -510,7 +555,7 @@ func TestForceRecordHandler_Auth(t *testing.T) {
 	t.Run("works without credentials when auth disabled", func(t *testing.T) {
 		dir := t.TempDir()
 		var flag atomic.Bool
-		srv := NewServer("0", dir, "", &flag, nil)
+		srv := NewServer("0", dir, "", &flag, nil, nil)
 
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/record", http.NoBody)
 		require.NoError(t, err)
@@ -529,7 +574,7 @@ func TestGETEndpoints_WithAuthEnabled(t *testing.T) {
 
 	var forceFlag atomic.Bool
 	var recFlag atomic.Bool
-	srv := NewServer("0", dir, string(hash), &forceFlag, &recFlag)
+	srv := NewServer("0", dir, string(hash), &forceFlag, &recFlag, nil)
 	srv.warnCapacity = 100
 
 	t.Run("index page accessible without credentials", func(t *testing.T) {
@@ -625,7 +670,7 @@ func TestLiveStreamHandler(t *testing.T) {
 		dir := t.TempDir()
 		var recording atomic.Bool
 		recording.Store(true)
-		srv := NewServer("0", dir, "", nil, &recording)
+		srv := NewServer("0", dir, "", nil, &recording, nil)
 
 		req := newRequest(t, "/live/test.mp3")
 		rec := serveHTTP(srv, req)
@@ -637,7 +682,7 @@ func TestLiveStreamHandler(t *testing.T) {
 		dir := setupTestDir(t)
 		var recording atomic.Bool
 		recording.Store(true)
-		srv := NewServer("0", dir, "", nil, &recording)
+		srv := NewServer("0", dir, "", nil, &recording, nil)
 
 		// stop recording after a short delay so tailFile exits
 		go func() {

--- a/app/server/static/index.html
+++ b/app/server/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {{if or .Recording .RecordRequested}}<meta http-equiv="refresh" content="5">{{end}}
+    {{if or .Recording .RecordRequested}}<meta http-equiv="refresh" content="5">{{else if .InWindow}}<meta http-equiv="refresh" content="60">{{end}}
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
@@ -12,7 +12,7 @@
   </head>
   <body>
     <main class="container" style="max-width:720px;margin:auto">
-      <h1>Stream Recorder</h1>
+      <h1>Stream Recorder{{if .InWindow}} <small><mark>LIVE WINDOW · {{.ShowStatus}}</mark></small>{{end}}</h1>
 
       {{if .ShowForceRecord}}
       {{if .Recording}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: streamrecorder
 
     ports:
-    - 8080:8080
+    - 8098:8080
 
     volumes:
     - ./records:/records
@@ -12,7 +12,9 @@ services:
     environment:
       - PORT=8080
       - DIR=/records
-      #- SCHEDULE=true
+      - DBG=true
+      - TZ=UTC
+      - SCHEDULE=true
       #- RETENTION_DAYS=30
       #- NEWS_API=https://news.radio-t.com/api/v1
       #- AUTH_PASSWD=$$2y$$10$$... # bcrypt hash for POST /record auth (use $$ to escape $ in compose)


### PR DESCRIPTION
## Summary
- Replace noisy per-tick debug messages with transition-based logging: INFO on window entry/exit, throttled DEBUG for stream checks (~1/min instead of every 5s)
- Add duration and file size to the "finished recording" log message
- Add "stream lost, waiting for reconnect" INFO log when stream drops mid-session
- Show a "LIVE WINDOW · Xm to show" badge next to the heading in the web UI when inside the recording window
- Auto-refresh the UI every 60s when in window (to update the countdown), 5s when recording
- Set `TZ=UTC` and enable `DBG` + `SCHEDULE` in docker-compose.yml defaults

### Logging before/after

**Before:** `DEBUG stream is not available` every 5s, no window transition info

**After:**
```
INFO  entered recording window  show_in=1h32m
DEBUG waiting for stream  checks=12
INFO  started recording 999 at ...
INFO  finished recording  episode=999 duration=2h15m size=156.3MB
INFO  stream lost, waiting for reconnect  episode=999
INFO  exited recording window
```

Web during stream window:

<img width="897" height="371" alt="image" src="https://github.com/user-attachments/assets/1d599217-ffca-431a-8713-4602adc71ccd" />
