### PR TITLE
Improve schedule UI, recording metadata, and chapter detection

### DIFF
--- a/app/chapters/chapters.go
+++ b/app/chapters/chapters.go
@@ -26,20 +26,23 @@ type NewsProvider interface {
 
 // ChapterTracker collects chapter markers by long-polling the news API for topic changes.
 type ChapterTracker struct {
-	news       NewsProvider
-	nowFn      func() time.Time
-	retryDelay time.Duration
+	news          NewsProvider
+	nowFn         func() time.Time
+	showStartHour int // hour (UTC) when the show starts, for stale topic detection
+	retryDelay    time.Duration
 
 	mu       sync.RWMutex
 	chapters []Chapter
 }
 
-// NewChapterTracker creates a new chapter tracker with the given news provider and time function.
-func NewChapterTracker(news NewsProvider, nowFn func() time.Time) *ChapterTracker {
+// NewChapterTracker creates a new chapter tracker with the given news provider, time function
+// and show start hour (UTC). Topics activated before the show start hour are treated as stale.
+func NewChapterTracker(news NewsProvider, nowFn func() time.Time, showStartHour int) *ChapterTracker {
 	return &ChapterTracker{ //nolint:exhaustruct // mu and chapters use zero values
-		news:       news,
-		nowFn:      nowFn,
-		retryDelay: 5 * time.Second,
+		news:          news,
+		nowFn:         nowFn,
+		showStartHour: showStartHour,
+		retryDelay:    5 * time.Second,
 	}
 }
 
@@ -54,6 +57,9 @@ func (ct *ChapterTracker) Run(ctx context.Context) {
 }
 
 // fetchInitialTopic fetches the current active topic and records it as the first chapter.
+// if the topic was activated before the show start (20:00 UTC), it's a leftover and we insert
+// a "Вступление" intro chapter instead. This works correctly on restarts because a topic set
+// during the show (e.g. at 20:15) will have ActiveTS after 20:00.
 func (ct *ChapterTracker) fetchInitialTopic(ctx context.Context, startTime time.Time) string {
 	id, err := ct.news.FetchActiveID(ctx)
 	if err != nil {
@@ -62,8 +68,43 @@ func (ct *ChapterTracker) fetchInitialTopic(ctx context.Context, startTime time.
 		}
 		return ""
 	}
-	ct.fetchAndAddChapter(ctx, id, startTime, startTime)
+
+	article, err := ct.news.FetchArticle(ctx, id)
+	if err != nil {
+		if ctx.Err() == nil {
+			slog.Warn("failed to fetch initial article", "id", id, "error", err)
+		}
+		return id
+	}
+
+	ct.mu.Lock()
+	if ct.isStaleTopicForShow(article.ActiveTS, startTime) {
+		ct.chapters = append(ct.chapters, Chapter{Title: "Вступление", Link: "", Offset: 0})
+		slog.Info("initial topic predates show, added intro chapter",
+			"active_since", article.ActiveTS.Format(time.RFC3339),
+			"recording_start", startTime.Format(time.RFC3339))
+	} else {
+		ct.chapters = append(ct.chapters, Chapter{
+			Title:  article.Title,
+			Link:   article.Link,
+			Offset: 0,
+		})
+	}
+	ct.mu.Unlock()
 	return id
+}
+
+// isStaleTopicForShow checks if a topic was activated before the show started.
+// the show starts at showStartHour UTC on the same day as the recording.
+// returns true if the topic predates the show start, meaning it's a leftover.
+func (ct *ChapterTracker) isStaleTopicForShow(activeTS, recordingStart time.Time) bool {
+	if activeTS.IsZero() {
+		return false // no timestamp available, assume topic is current
+	}
+	showStart := time.Date(
+		recordingStart.Year(), recordingStart.Month(), recordingStart.Day(),
+		ct.showStartHour, 0, 0, 0, time.UTC)
+	return activeTS.Before(showStart)
 }
 
 // pollForChanges long-polls the news API for topic changes until ctx is cancelled.

--- a/app/chapters/chapters_test.go
+++ b/app/chapters/chapters_test.go
@@ -19,7 +19,7 @@ const (
 func TestChapterTracker_CollectsTopicChanges(t *testing.T) {
 	t.Parallel()
 
-	baseTime := time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC)
+	baseTime := time.Date(2026, 3, 27, 20, 30, 0, 0, time.UTC) // during the show
 	var currentTime atomic.Int64
 	currentTime.Store(baseTime.UnixNano())
 	nowFn := func() time.Time { return time.Unix(0, currentTime.Load()) }
@@ -34,9 +34,11 @@ func TestChapterTracker_CollectsTopicChanges(t *testing.T) {
 		FetchArticleFunc: func(_ context.Context, id string) (Article, error) {
 			switch id {
 			case testTopic1:
-				return Article{Title: "First Topic", Link: "https://example.com/1"}, nil
+				return Article{Title: "First Topic", Link: "https://example.com/1",
+					ActiveTS: baseTime.Add(-5 * time.Minute)}, nil // activated at 20:25, after show start
 			case testTopic2:
-				return Article{Title: "Second Topic", Link: "https://example.com/2"}, nil
+				return Article{Title: "Second Topic", Link: "https://example.com/2",
+					ActiveTS: baseTime.Add(10 * time.Minute)}, nil
 			default:
 				return Article{}, fmt.Errorf("unknown article %s", id)
 			}
@@ -56,7 +58,7 @@ func TestChapterTracker_CollectsTopicChanges(t *testing.T) {
 		},
 	}
 
-	tracker := NewChapterTracker(mock, nowFn)
+	tracker := NewChapterTracker(mock, nowFn, 20)
 	tracker.Run(ctx)
 
 	chapters := tracker.Chapters()
@@ -69,6 +71,91 @@ func TestChapterTracker_CollectsTopicChanges(t *testing.T) {
 	assert.Equal(t, "Second Topic", chapters[1].Title)
 	assert.Equal(t, "https://example.com/2", chapters[1].Link)
 	assert.Equal(t, 10*time.Minute, chapters[1].Offset)
+}
+
+func TestChapterTracker_StaleTopicAddsIntro(t *testing.T) {
+	t.Parallel()
+
+	// recording starts at 20:15 UTC (15 min into the show window)
+	baseTime := time.Date(2026, 3, 28, 20, 15, 0, 0, time.UTC)
+	var currentTime atomic.Int64
+	currentTime.Store(baseTime.UnixNano())
+	nowFn := func() time.Time { return time.Unix(0, currentTime.Load()) }
+
+	var waitCalls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mock := &NewsProviderMock{
+		FetchActiveIDFunc: func(_ context.Context) (string, error) {
+			return testTopic1, nil
+		},
+		FetchArticleFunc: func(_ context.Context, id string) (Article, error) {
+			switch id {
+			case testTopic1:
+				// topic was activated at 19:00 — before show start (20:00), stale
+				return Article{Title: "Old Topic", Link: "https://example.com/old",
+					ActiveTS: time.Date(2026, 3, 28, 19, 0, 0, 0, time.UTC)}, nil
+			case testTopic2:
+				// topic activated at 20:30 — during the show, valid
+				return Article{Title: "New Topic", Link: "https://example.com/new",
+					ActiveTS: time.Date(2026, 3, 28, 20, 30, 0, 0, time.UTC)}, nil
+			default:
+				return Article{}, fmt.Errorf("unknown article %s", id)
+			}
+		},
+		WaitActiveChangeFunc: func(_ context.Context, _ time.Duration) (string, error) {
+			call := waitCalls.Add(1)
+			if call == 1 {
+				currentTime.Store(baseTime.Add(15 * time.Minute).UnixNano())
+				return testTopic2, nil
+			}
+			cancel()
+			return "", ctx.Err()
+		},
+	}
+
+	tracker := NewChapterTracker(mock, nowFn, 20)
+	tracker.Run(ctx)
+
+	chapters := tracker.Chapters()
+	require.Len(t, chapters, 2)
+
+	assert.Equal(t, "Вступление", chapters[0].Title, "topic from before show start should be replaced with intro")
+	assert.Empty(t, chapters[0].Link, "intro chapter should have no link")
+	assert.Equal(t, time.Duration(0), chapters[0].Offset)
+
+	assert.Equal(t, "New Topic", chapters[1].Title)
+	assert.Equal(t, 15*time.Minute, chapters[1].Offset)
+}
+
+func TestChapterTracker_RestartKeepsCurrentTopic(t *testing.T) {
+	// recorder restarts at 21:00, topic was set at 20:15 (during the show) — should keep it
+	t.Parallel()
+
+	baseTime := time.Date(2026, 3, 28, 21, 0, 0, 0, time.UTC)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mock := &NewsProviderMock{
+		FetchActiveIDFunc: func(_ context.Context) (string, error) {
+			return testTopic1, nil
+		},
+		FetchArticleFunc: func(_ context.Context, _ string) (Article, error) {
+			// topic set at 20:15 — after show start, valid even though 45min before restart
+			return Article{Title: "Current Topic", Link: "https://example.com/current",
+				ActiveTS: time.Date(2026, 3, 28, 20, 15, 0, 0, time.UTC)}, nil
+		},
+		WaitActiveChangeFunc: func(_ context.Context, _ time.Duration) (string, error) {
+			cancel()
+			return "", ctx.Err()
+		},
+	}
+
+	tracker := NewChapterTracker(mock, func() time.Time { return baseTime }, 20)
+	tracker.Run(ctx)
+
+	chapters := tracker.Chapters()
+	require.Len(t, chapters, 1)
+	assert.Equal(t, "Current Topic", chapters[0].Title, "topic activated during show should be kept on restart")
 }
 
 func TestChapterTracker_APIErrorRetry(t *testing.T) {
@@ -101,7 +188,7 @@ func TestChapterTracker_APIErrorRetry(t *testing.T) {
 		},
 	}
 
-	tracker := NewChapterTracker(mock, nowFn)
+	tracker := NewChapterTracker(mock, nowFn, 20)
 	tracker.retryDelay = time.Millisecond // fast retry for test
 	tracker.Run(ctx)
 
@@ -131,7 +218,7 @@ func TestChapterTracker_ContextCancellation(t *testing.T) {
 		},
 	}
 
-	tracker := NewChapterTracker(mock, time.Now)
+	tracker := NewChapterTracker(mock, time.Now, 20)
 
 	done := make(chan struct{})
 	go func() {
@@ -175,7 +262,7 @@ func TestChapterTracker_SameIDNoNewChapter(t *testing.T) {
 		},
 	}
 
-	tracker := NewChapterTracker(mock, nowFn)
+	tracker := NewChapterTracker(mock, nowFn, 20)
 	tracker.Run(ctx)
 
 	chapters := tracker.Chapters()
@@ -212,7 +299,7 @@ func TestChapterTracker_InitialFetchError(t *testing.T) {
 		},
 	}
 
-	tracker := NewChapterTracker(mock, nowFn)
+	tracker := NewChapterTracker(mock, nowFn, 20)
 	tracker.Run(ctx)
 
 	// should still collect chapters from long-poll even if initial fetch failed
@@ -254,7 +341,7 @@ func TestChapterTracker_ArticleFetchError(t *testing.T) {
 		},
 	}
 
-	tracker := NewChapterTracker(mock, nowFn)
+	tracker := NewChapterTracker(mock, nowFn, 20)
 	tracker.Run(ctx)
 
 	// should only have the first chapter; second was skipped due to article fetch error
@@ -266,7 +353,7 @@ func TestChapterTracker_ArticleFetchError(t *testing.T) {
 func TestChapterTracker_ChaptersThreadSafe(t *testing.T) {
 	t.Parallel()
 
-	tracker := NewChapterTracker(nil, time.Now)
+	tracker := NewChapterTracker(nil, time.Now, 20)
 
 	// concurrently read Chapters while adding chapters
 	done := make(chan struct{})

--- a/app/chapters/inject.go
+++ b/app/chapters/inject.go
@@ -3,181 +3,70 @@ package chapters
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"time"
+
+	"github.com/radio-t/stream-recorder/app/id3"
 )
 
-// putSyncsafe encodes size as a 4-byte syncsafe integer (7 bits per byte).
-func putSyncsafe(dst []byte, size int) {
-	dst[0] = byte(size>>21) & 0x7f //nolint:gosec
-	dst[1] = byte(size>>14) & 0x7f //nolint:gosec
-	dst[2] = byte(size>>7) & 0x7f  //nolint:gosec
-	dst[3] = byte(size) & 0x7f     //nolint:gosec
-}
-
-// readSyncsafe decodes a 4-byte syncsafe integer (7 bits per byte).
-func readSyncsafe(b []byte) int {
-	return int(b[0])<<21 | int(b[1])<<14 | int(b[2])<<7 | int(b[3])
-}
-
-// id3TextFrame builds an ID3v2.4 text frame (UTF-8 encoding).
-func id3TextFrame(id, text string) []byte {
-	data := append([]byte{3}, []byte(text)...) // 0x03 = UTF-8 encoding
-	frame := make([]byte, 10+len(data))
-	copy(frame[0:4], id)
-	putSyncsafe(frame[4:8], len(data))
-	// frame[8:10] = flags, left as 0x0000
-	copy(frame[10:], data)
-	return frame
-}
-
-// id3ChapFrame builds an ID3v2.4 CHAP frame with embedded TIT2 and optional WXXX sub-frames.
-func id3ChapFrame(id, title, link string, start, end time.Duration) []byte {
+// chapFrame builds an ID3v2.4 CHAP frame with embedded TIT2 and optional WXXX sub-frames.
+func chapFrame(elemID, title, link string, start, end time.Duration) []byte {
 	var times [16]byte
 	binary.BigEndian.PutUint32(times[0:4], uint32(start.Milliseconds())) //nolint:gosec // duration always positive and small
 	binary.BigEndian.PutUint32(times[4:8], uint32(end.Milliseconds()))   //nolint:gosec // duration always positive and small
 	binary.BigEndian.PutUint32(times[8:12], 0xFFFFFFFF)                  // start offset: unused
 	binary.BigEndian.PutUint32(times[12:16], 0xFFFFFFFF)                 // end offset: unused
 
-	data := make([]byte, 0, len(id)+1+16)
-	data = append(data, id...)
+	data := make([]byte, 0, len(elemID)+1+16)
+	data = append(data, elemID...)
 	data = append(data, 0) // null terminator
 	data = append(data, times[:]...)
-	data = append(data, id3TextFrame("TIT2", title)...)
+	data = append(data, id3.TextFrame("TIT2", title)...)
 	if link != "" {
-		data = append(data, id3WXXXFrame(link)...)
+		data = append(data, wxxxFrame(link)...)
 	}
 
 	frame := make([]byte, 10+len(data))
 	copy(frame[0:4], "CHAP")
-	putSyncsafe(frame[4:8], len(data))
+	id3.PutSyncsafe(frame[4:8], len(data))
 	copy(frame[10:], data)
 	return frame
 }
 
-// id3WXXXFrame builds an ID3v2.4 WXXX (user-defined URL link) frame.
-func id3WXXXFrame(url string) []byte {
+// wxxxFrame builds an ID3v2.4 WXXX (user-defined URL link) frame.
+func wxxxFrame(url string) []byte {
 	data := make([]byte, 0, 2+len(url))
 	data = append(data, 0x00, 0x00) // encoding (ISO-8859-1) + empty description null terminator
 	data = append(data, url...)
 
 	frame := make([]byte, 10+len(data))
 	copy(frame[0:4], "WXXX")
-	putSyncsafe(frame[4:8], len(data))
+	id3.PutSyncsafe(frame[4:8], len(data))
 	copy(frame[10:], data)
 	return frame
 }
 
-// id3CTOCFrame builds an ID3v2.4 CTOC (table of contents) frame referencing the given chapter IDs.
-func id3CTOCFrame(chapIDs []string) []byte {
+// ctocFrame builds an ID3v2.4 CTOC (table of contents) frame referencing the given chapter IDs.
+func ctocFrame(chapIDs []string) []byte {
 	data := []byte("toc0\x00")                    // element ID null-terminated
 	data = append(data, 0x03, byte(len(chapIDs))) //nolint:gosec // flags (top-level + ordered) + entry count
-	for _, id := range chapIDs {
-		data = append(data, []byte(id)...)
+	for _, elemID := range chapIDs {
+		data = append(data, []byte(elemID)...)
 		data = append(data, 0)
 	}
 
 	frame := make([]byte, 10+len(data))
 	copy(frame[0:4], "CTOC")
-	putSyncsafe(frame[4:8], len(data))
+	id3.PutSyncsafe(frame[4:8], len(data))
 	copy(frame[10:], data)
 	return frame
 }
 
-// InjectChapters opens an MP3 file and writes CHAP/CTOC frames into its ID3v2 header.
-// uses a single-pass copy to a temp file, then atomic rename to replace the original.
-// does nothing when chapters is empty.
-func InjectChapters(filePath string, chapters []Chapter) error {
+// BuildChapterFrames builds CHAP and CTOC frame bytes for the given chapters.
+// caps at 255 chapters (ID3v2 CTOC entry count is a single byte).
+func BuildChapterFrames(chapters []Chapter) []byte {
 	if len(chapters) == 0 {
 		return nil
 	}
-
-	srcInfo, err := os.Stat(filePath)
-	if err != nil {
-		return fmt.Errorf("stat file for chapter injection: %w", err)
-	}
-
-	src, err := os.Open(filePath) //nolint:gosec // caller provides path
-	if err != nil {
-		return fmt.Errorf("open file for chapter injection: %w", err)
-	}
-	defer src.Close() //nolint:errcheck
-
-	// read existing ID3 header
-	header := make([]byte, 10)
-	if _, err := io.ReadFull(src, header); err != nil {
-		return fmt.Errorf("read ID3 header: %w", err)
-	}
-	if string(header[0:3]) != "ID3" {
-		return fmt.Errorf("not an ID3v2 file")
-	}
-	oldSize := readSyncsafe(header[6:10])
-
-	chapFrames := buildChapterFrames(chapters)
-	newSize := oldSize + len(chapFrames)
-	if newSize > 0x0FFFFFFF {
-		return fmt.Errorf("ID3 tag size %d exceeds syncsafe maximum", newSize)
-	}
-
-	// update header with new size, build the new file in a temp, then rename atomically
-	putSyncsafe(header[6:10], newSize)
-	tmpPath, err := writeChapteredFile(filepath.Dir(filePath), header, src, int64(oldSize), chapFrames)
-	if err != nil {
-		return err
-	}
-	if err := os.Chmod(tmpPath, srcInfo.Mode().Perm()); err != nil {
-		os.Remove(tmpPath) //nolint:errcheck,gosec
-		return fmt.Errorf("set permissions on temp file: %w", err)
-	}
-	if err := os.Rename(tmpPath, filePath); err != nil {
-		os.Remove(tmpPath) //nolint:errcheck,gosec
-		return fmt.Errorf("rename temp file: %w", err)
-	}
-	return nil
-}
-
-// writeChapteredFile creates a temp file containing: updated ID3 header + existing frames +
-// chapter frames + remaining audio from src. Returns the temp file path on success.
-// On failure, the temp file is removed.
-func writeChapteredFile(dir string, header []byte, src io.Reader, frameSize int64, chapFrames []byte) (string, error) {
-	tmp, err := os.CreateTemp(dir, "chapters-*.tmp")
-	if err != nil {
-		return "", fmt.Errorf("create temp file for chapter injection: %w", err)
-	}
-	tmpPath := tmp.Name()
-	ok := false
-	defer func() {
-		tmp.Close() //nolint:errcheck,gosec
-		if !ok {
-			os.Remove(tmpPath) //nolint:errcheck,gosec
-		}
-	}()
-
-	if _, err := tmp.Write(header); err != nil {
-		return "", fmt.Errorf("write header: %w", err)
-	}
-	if _, err := io.CopyN(tmp, src, frameSize); err != nil {
-		return "", fmt.Errorf("copy existing frames: %w", err)
-	}
-	if _, err := tmp.Write(chapFrames); err != nil {
-		return "", fmt.Errorf("write chapter frames: %w", err)
-	}
-	if _, err := io.Copy(tmp, src); err != nil {
-		return "", fmt.Errorf("copy audio data: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return "", fmt.Errorf("close temp file: %w", err)
-	}
-
-	ok = true
-	return tmpPath, nil
-}
-
-// buildChapterFrames builds CHAP and CTOC frame bytes for the given chapters.
-// caps at 255 chapters (ID3v2 CTOC entry count is a single byte).
-func buildChapterFrames(chapters []Chapter) []byte {
 	if len(chapters) > 255 { //nolint:mnd // ID3v2 CTOC entry count is a single byte
 		chapters = chapters[:255]
 	}
@@ -192,7 +81,7 @@ func buildChapterFrames(chapters []Chapter) []byte {
 		} else {
 			endTime = time.Duration(0xFFFFFFFF) * time.Millisecond // unknown end
 		}
-		frames = append(frames, id3ChapFrame(chapID, ch.Title, ch.Link, ch.Offset, endTime)...)
+		frames = append(frames, chapFrame(chapID, ch.Title, ch.Link, ch.Offset, endTime)...)
 	}
-	return append(frames, id3CTOCFrame(chapIDs)...)
+	return append(frames, ctocFrame(chapIDs)...)
 }

--- a/app/chapters/inject_test.go
+++ b/app/chapters/inject_test.go
@@ -11,40 +11,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/radio-t/stream-recorder/app/id3"
 )
 
-func TestReadSyncsafe(t *testing.T) {
-	tests := []struct {
-		name string
-		data []byte
-		want int
-	}{
-		{name: "zero", data: []byte{0, 0, 0, 0}, want: 0},
-		{name: "127", data: []byte{0, 0, 0, 127}, want: 127},
-		{name: "128", data: []byte{0, 0, 1, 0}, want: 128},
-		{name: "255", data: []byte{0, 0, 1, 127}, want: 255},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, readSyncsafe(tc.data))
-		})
-	}
-}
-
-func TestReadPutSyncsafeRoundtrip(t *testing.T) {
-	for _, val := range []int{0, 1, 127, 128, 255, 256, 1000, 16383, 16384, 100000} {
-		dst := make([]byte, 4)
-		putSyncsafe(dst, val)
-		assert.Equal(t, val, readSyncsafe(dst), "roundtrip for %d", val)
-	}
-}
-
-func TestID3ChapFrame(t *testing.T) {
-	frame := id3ChapFrame("chp0", "Test Chapter", "https://example.com", 0, 30*time.Second)
+func TestChapFrame(t *testing.T) {
+	frame := chapFrame("chp0", "Test Chapter", "https://example.com", 0, 30*time.Second)
 
 	// verify frame header
 	assert.Equal(t, "CHAP", string(frame[0:4]))
-	size := readSyncsafe(frame[4:8])
+	size := id3.ReadSyncsafe(frame[4:8])
 	assert.Equal(t, len(frame)-10, size)
 	assert.Equal(t, []byte{0, 0}, frame[8:10], "flags should be zero")
 
@@ -66,7 +42,7 @@ func TestID3ChapFrame(t *testing.T) {
 	// embedded TIT2 sub-frame
 	subFrames := body[21:]
 	assert.Equal(t, "TIT2", string(subFrames[0:4]))
-	tit2Size := readSyncsafe(subFrames[4:8])
+	tit2Size := id3.ReadSyncsafe(subFrames[4:8])
 	assert.Equal(t, byte(3), subFrames[10], "TIT2 encoding should be UTF-8")
 	tit2Text := string(subFrames[11 : 10+tit2Size])
 	assert.Equal(t, "Test Chapter", tit2Text)
@@ -74,15 +50,15 @@ func TestID3ChapFrame(t *testing.T) {
 	// embedded WXXX sub-frame after TIT2
 	wxxx := subFrames[10+tit2Size:]
 	assert.Equal(t, "WXXX", string(wxxx[0:4]))
-	wxxxSize := readSyncsafe(wxxx[4:8])
+	wxxxSize := id3.ReadSyncsafe(wxxx[4:8])
 	assert.Equal(t, byte(0), wxxx[10], "WXXX encoding should be ISO-8859-1")
 	assert.Equal(t, byte(0), wxxx[11], "WXXX description should be empty")
 	url := string(wxxx[12 : 10+wxxxSize])
 	assert.Equal(t, "https://example.com", url)
 }
 
-func TestID3ChapFrameNoLink(t *testing.T) {
-	frame := id3ChapFrame("chp1", "No Link Chapter", "", 5*time.Second, 10*time.Second)
+func TestChapFrameNoLink(t *testing.T) {
+	frame := chapFrame("chp1", "No Link Chapter", "", 5*time.Second, 10*time.Second)
 
 	body := frame[10:]
 	assert.Equal(t, []byte("chp1\x00"), body[0:5])
@@ -96,17 +72,17 @@ func TestID3ChapFrameNoLink(t *testing.T) {
 	// should have TIT2 but no WXXX
 	subFrames := body[21:]
 	assert.Equal(t, "TIT2", string(subFrames[0:4]))
-	tit2Size := readSyncsafe(subFrames[4:8])
+	tit2Size := id3.ReadSyncsafe(subFrames[4:8])
 
 	remaining := subFrames[10+tit2Size:]
 	assert.Empty(t, remaining, "no WXXX frame when link is empty")
 }
 
-func TestID3CTOCFrame(t *testing.T) {
-	frame := id3CTOCFrame([]string{"chp0", "chp1", "chp2"})
+func TestCTOCFrame(t *testing.T) {
+	frame := ctocFrame([]string{"chp0", "chp1", "chp2"})
 
 	assert.Equal(t, "CTOC", string(frame[0:4]))
-	size := readSyncsafe(frame[4:8])
+	size := id3.ReadSyncsafe(frame[4:8])
 	assert.Equal(t, len(frame)-10, size)
 	assert.Equal(t, []byte{0, 0}, frame[8:10], "flags should be zero")
 
@@ -123,29 +99,47 @@ func TestID3CTOCFrame(t *testing.T) {
 func writeTestMP3(t *testing.T, filePath, audioData string) {
 	t.Helper()
 	var buf bytes.Buffer
-	frames := id3TextFrame("TIT2", "Test")
-	header := []byte{'I', 'D', '3', 4, 0, 0, 0, 0, 0, 0}
-	putSyncsafe(header[6:10], len(frames))
-	buf.Write(header)
-	buf.Write(frames)
+	frames := id3.TextFrame("TIT2", "Test")
+	require.NoError(t, id3.WriteHeader(&buf, frames))
 	buf.Write([]byte(audioData))
 	require.NoError(t, os.MkdirAll(filepath.Dir(filePath), 0o750))
 	require.NoError(t, os.WriteFile(filePath, buf.Bytes(), 0o600))
 }
 
-func TestInjectChapters(t *testing.T) {
+func TestBuildChapterFrames(t *testing.T) {
+	t.Parallel()
+	chaps := []Chapter{
+		{Title: "Introduction", Link: "https://example.com/intro", Offset: 0},
+		{Title: "Main Topic", Link: "https://example.com/main", Offset: 5 * time.Minute},
+		{Title: "Wrap Up", Link: "", Offset: 45 * time.Minute},
+	}
+	frames := BuildChapterFrames(chaps)
+	assert.Contains(t, string(frames), "CHAP")
+	assert.Contains(t, string(frames), "CTOC")
+	assert.Contains(t, string(frames), "Introduction")
+	assert.Contains(t, string(frames), "Main Topic")
+	assert.Contains(t, string(frames), "Wrap Up")
+}
+
+func TestBuildChapterFramesEmpty(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, BuildChapterFrames(nil))
+	assert.Nil(t, BuildChapterFrames([]Chapter{}))
+}
+
+func TestInjectFramesWithChapters(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "test.mp3")
 	audioData := "fake-mp3-audio-data-1234567890"
 	writeTestMP3(t, filePath, audioData)
 
-	chapters := []Chapter{
+	chaps := []Chapter{
 		{Title: "Introduction", Link: "https://example.com/intro", Offset: 0},
 		{Title: "Main Topic", Link: "https://example.com/main", Offset: 5 * time.Minute},
 		{Title: "Wrap Up", Link: "", Offset: 45 * time.Minute},
 	}
-	require.NoError(t, InjectChapters(filePath, chapters))
+	require.NoError(t, id3.InjectFrames(filePath, BuildChapterFrames(chaps)))
 
 	data, err := os.ReadFile(filePath) //nolint:gosec // test file
 	require.NoError(t, err)
@@ -160,33 +154,7 @@ func TestInjectChapters(t *testing.T) {
 	assert.Contains(t, string(data), "Wrap Up")
 }
 
-func TestInjectChaptersEmpty(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	filePath := filepath.Join(dir, "test.mp3")
-	writeTestMP3(t, filePath, "audio")
-
-	original, err := os.ReadFile(filePath) //nolint:gosec // test file
-	require.NoError(t, err)
-
-	require.NoError(t, InjectChapters(filePath, nil))
-
-	after, err := os.ReadFile(filePath) //nolint:gosec // test file
-	require.NoError(t, err)
-	assert.Equal(t, original, after, "file should be unchanged with no chapters")
-}
-
-func TestInjectChaptersNonexistentFile(t *testing.T) {
-	t.Parallel()
-	chapters := []Chapter{
-		{Title: "Test", Offset: 0},
-	}
-	err := InjectChapters("/nonexistent/path/file.mp3", chapters)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "chapter injection")
-}
-
-func TestInjectChaptersNonID3File(t *testing.T) {
+func TestInjectFramesNonID3File(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "plain.mp3")
@@ -194,10 +162,7 @@ func TestInjectChaptersNonID3File(t *testing.T) {
 	// write a file without an ID3 header (raw MP3 frame, at least 10 bytes for header read)
 	require.NoError(t, os.WriteFile(filePath, []byte{0xFF, 0xFB, 0x90, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, 0o600))
 
-	chapters := []Chapter{
-		{Title: "Test", Offset: 0},
-	}
-	err := InjectChapters(filePath, chapters)
+	err := id3.InjectFrames(filePath, BuildChapterFrames([]Chapter{{Title: "Test", Offset: 0}}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not an ID3v2 file")
 }

--- a/app/id3/id3.go
+++ b/app/id3/id3.go
@@ -1,0 +1,159 @@
+// Package id3 provides ID3v2.4 frame building and injection primitives.
+package id3
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// TextFrame builds an ID3v2.4 text frame (UTF-8 encoding).
+func TextFrame(id, text string) []byte {
+	data := append([]byte{3}, []byte(text)...) // 0x03 = UTF-8 encoding
+	frame := make([]byte, 10+len(data))
+	copy(frame[0:4], id)
+	PutSyncsafe(frame[4:8], len(data))
+	// frame[8:10] = flags, left as 0x0000
+	copy(frame[10:], data)
+	return frame
+}
+
+// WriteHeader writes a complete ID3v2.4 header wrapping the given frames.
+func WriteHeader(w io.Writer, frames []byte) error {
+	header := []byte{'I', 'D', '3', 4, 0, 0, 0, 0, 0, 0}
+	PutSyncsafe(header[6:10], len(frames))
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	_, err := w.Write(frames)
+	return err
+}
+
+// InjectFrames appends extra frames into an existing MP3 file's ID3v2 header.
+// uses a single-pass copy to a temp file, then atomic rename to replace the original.
+func InjectFrames(filePath string, extraFrames []byte) error {
+	srcInfo, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+
+	src, err := os.Open(filePath) //nolint:gosec // caller provides path
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer src.Close() //nolint:errcheck
+
+	header := make([]byte, 10)
+	if _, err := io.ReadFull(src, header); err != nil {
+		return fmt.Errorf("read ID3 header: %w", err)
+	}
+	if string(header[0:3]) != "ID3" {
+		return fmt.Errorf("not an ID3v2 file")
+	}
+	oldSize := ReadSyncsafe(header[6:10])
+	PutSyncsafe(header[6:10], oldSize+len(extraFrames))
+
+	tmpPath, err := rewriteFile(filepath.Dir(filePath), header, src, int64(oldSize), extraFrames)
+	if err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, srcInfo.Mode().Perm()); err != nil {
+		os.Remove(tmpPath) //nolint:errcheck,gosec
+		return fmt.Errorf("set permissions: %w", err)
+	}
+	return os.Rename(tmpPath, filePath)
+}
+
+// rewriteFile creates a temp file with: updated header + existing frames + extra frames + audio.
+func rewriteFile(dir string, header []byte, src io.Reader, frameSize int64, extra []byte) (string, error) {
+	tmp, err := os.CreateTemp(dir, "id3-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	ok := false
+	defer func() {
+		tmp.Close() //nolint:errcheck,gosec
+		if !ok {
+			os.Remove(tmpPath) //nolint:errcheck,gosec
+		}
+	}()
+
+	if _, err := tmp.Write(header); err != nil {
+		return "", fmt.Errorf("write header: %w", err)
+	}
+	if _, err := io.CopyN(tmp, src, frameSize); err != nil {
+		return "", fmt.Errorf("copy existing frames: %w", err)
+	}
+	if _, err := tmp.Write(extra); err != nil {
+		return "", fmt.Errorf("write extra frames: %w", err)
+	}
+	if _, err := io.Copy(tmp, src); err != nil {
+		return "", fmt.Errorf("copy audio data: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close temp file: %w", err)
+	}
+	ok = true
+	return tmpPath, nil
+}
+
+// ReadTLEN reads the TLEN (track length) value from an MP3 file's ID3v2 header.
+// returns the duration in seconds, or 0 if TLEN is not found or the file is not valid ID3v2.
+func ReadTLEN(filePath string) int64 {
+	f, err := os.Open(filePath) //nolint:gosec // caller provides path
+	if err != nil {
+		return 0
+	}
+	defer f.Close() //nolint:errcheck
+
+	header := make([]byte, 10)
+	if _, err := io.ReadFull(f, header); err != nil || string(header[0:3]) != "ID3" {
+		return 0
+	}
+
+	tagSize := ReadSyncsafe(header[6:10])
+	const maxTagSize = 1 << 20 // 1MB cap to avoid excessive allocation on corrupt files
+	if tagSize <= 0 || tagSize > maxTagSize {
+		return 0
+	}
+
+	buf := make([]byte, tagSize)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return 0
+	}
+	return findTLEN(buf)
+}
+
+// findTLEN scans ID3 tag frame data for TLEN and returns duration in seconds.
+func findTLEN(buf []byte) int64 {
+	for len(buf) >= 10 {
+		frameID := string(buf[0:4])
+		sz := ReadSyncsafe(buf[4:8])
+		if sz == 0 || 10+sz > len(buf) {
+			return 0
+		}
+		if frameID == "TLEN" && sz > 1 {
+			if ms, err := strconv.ParseInt(string(buf[11:10+sz]), 10, 64); err == nil {
+				return ms / 1000 //nolint:mnd
+			}
+		}
+		buf = buf[10+sz:]
+	}
+	return 0
+}
+
+// PutSyncsafe encodes size as a 4-byte syncsafe integer (7 bits per byte).
+func PutSyncsafe(dst []byte, size int) {
+	dst[0] = byte(size>>21) & 0x7f //nolint:gosec
+	dst[1] = byte(size>>14) & 0x7f //nolint:gosec
+	dst[2] = byte(size>>7) & 0x7f  //nolint:gosec
+	dst[3] = byte(size) & 0x7f     //nolint:gosec
+}
+
+// ReadSyncsafe decodes a 4-byte syncsafe integer (7 bits per byte).
+func ReadSyncsafe(b []byte) int {
+	return int(b[0])<<21 | int(b[1])<<14 | int(b[2])<<7 | int(b[3])
+}

--- a/app/id3/id3_test.go
+++ b/app/id3/id3_test.go
@@ -1,0 +1,144 @@
+package id3
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPutSyncsafe(t *testing.T) {
+	tests := []struct {
+		name string
+		val  int
+		want []byte
+	}{
+		{name: "zero", val: 0, want: []byte{0, 0, 0, 0}},
+		{name: "127", val: 127, want: []byte{0, 0, 0, 127}},
+		{name: "128", val: 128, want: []byte{0, 0, 1, 0}},
+		{name: "255", val: 255, want: []byte{0, 0, 1, 127}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := make([]byte, 4)
+			PutSyncsafe(dst, tc.val)
+			assert.Equal(t, tc.want, dst)
+		})
+	}
+}
+
+func TestReadSyncsafe(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want int
+	}{
+		{name: "zero", data: []byte{0, 0, 0, 0}, want: 0},
+		{name: "127", data: []byte{0, 0, 0, 127}, want: 127},
+		{name: "128", data: []byte{0, 0, 1, 0}, want: 128},
+		{name: "255", data: []byte{0, 0, 1, 127}, want: 255},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ReadSyncsafe(tc.data))
+		})
+	}
+}
+
+func TestPutReadSyncsafeRoundtrip(t *testing.T) {
+	for _, val := range []int{0, 1, 127, 128, 255, 256, 1000, 16383, 16384, 100000} {
+		dst := make([]byte, 4)
+		PutSyncsafe(dst, val)
+		assert.Equal(t, val, ReadSyncsafe(dst), "roundtrip for %d", val)
+	}
+}
+
+func TestTextFrame(t *testing.T) {
+	frame := TextFrame("TIT2", "Hello")
+	assert.Equal(t, "TIT2", string(frame[0:4]))
+	sz := ReadSyncsafe(frame[4:8])
+	assert.Equal(t, len(frame)-10, sz)
+	assert.Equal(t, byte(3), frame[10], "encoding should be UTF-8")
+	assert.Equal(t, "Hello", string(frame[11:10+sz]))
+}
+
+func TestWriteHeader(t *testing.T) {
+	var buf bytes.Buffer
+	frames := TextFrame("TIT2", "Test")
+	require.NoError(t, WriteHeader(&buf, frames))
+
+	data := buf.Bytes()
+	assert.Equal(t, "ID3", string(data[0:3]))
+	assert.Equal(t, byte(4), data[3], "version 2.4")
+	size := ReadSyncsafe(data[6:10])
+	assert.Equal(t, len(frames), size)
+	assert.Equal(t, frames, data[10:])
+}
+
+func TestInjectFrames(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "test.mp3")
+
+	// create a minimal ID3v2 file
+	var buf bytes.Buffer
+	origFrames := TextFrame("TIT2", "Original")
+	require.NoError(t, WriteHeader(&buf, origFrames))
+	audioData := "fake-audio-data-12345"
+	buf.WriteString(audioData)
+	require.NoError(t, os.WriteFile(filePath, buf.Bytes(), 0o600))
+
+	// inject extra frames
+	extraFrames := TextFrame("TLEN", "9690000")
+	require.NoError(t, InjectFrames(filePath, extraFrames))
+
+	data, err := os.ReadFile(filePath) //nolint:gosec // test file
+	require.NoError(t, err)
+
+	assert.Equal(t, "ID3", string(data[:3]))
+	newSize := ReadSyncsafe(data[6:10])
+	assert.Equal(t, len(origFrames)+len(extraFrames), newSize, "tag size should include both original and extra frames")
+	assert.True(t, strings.HasSuffix(string(data), audioData), "audio data should be intact")
+	assert.Contains(t, string(data), "Original")
+	assert.Contains(t, string(data), "TLEN")
+	assert.Contains(t, string(data), "9690000")
+
+	// verify ReadTLEN can read back the injected value
+	assert.Equal(t, int64(9690), ReadTLEN(filePath), "ReadTLEN should return duration in seconds")
+}
+
+func TestReadTLEN_NoTLEN(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "no-tlen.mp3")
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteHeader(&buf, TextFrame("TIT2", "Test")))
+	buf.WriteString("audio")
+	require.NoError(t, os.WriteFile(filePath, buf.Bytes(), 0o600))
+
+	assert.Equal(t, int64(0), ReadTLEN(filePath), "should return 0 when TLEN is absent")
+}
+
+func TestReadTLEN_NonExistent(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, int64(0), ReadTLEN("/nonexistent/file.mp3"))
+}
+
+func TestFindTLEN(t *testing.T) {
+	t.Parallel()
+	// craft raw frame bytes: TIT2 frame + TLEN frame
+	frames := TextFrame("TIT2", "Test")
+	frames = append(frames, TextFrame("TLEN", "9698763")...)
+	assert.Equal(t, int64(9698), findTLEN(frames), "should find TLEN in frame sequence")
+}
+
+func TestFindTLEN_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, int64(0), findTLEN(nil))
+	assert.Equal(t, int64(0), findTLEN([]byte{}))
+}

--- a/app/main.go
+++ b/app/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -18,6 +19,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/radio-t/stream-recorder/app/chapters"
+	"github.com/radio-t/stream-recorder/app/id3"
 	"github.com/radio-t/stream-recorder/app/recorder"
 	"github.com/radio-t/stream-recorder/app/server"
 )
@@ -119,8 +121,8 @@ type runConfig struct {
 	schedule          bool // enable time-based recording window
 	tickInterval      time.Duration
 	nowFn             func() time.Time
-	newChapterTracker func() chapterProvider                 // nil = chapter tracking disabled
-	injectChapters    func(string, []chapters.Chapter) error // defaults to chapters.InjectChapters
+	newChapterTracker func() chapterProvider                             // nil = chapter tracking disabled
+	injectMetadata    func(string, time.Duration, chapterProvider) error // post-recording metadata injection
 }
 
 // recordingState holds mutable runtime state for the recording loop.
@@ -133,18 +135,21 @@ type recordingState struct {
 
 // newRunConfig creates a runConfig with standard defaults, optionally enabling chapter tracking.
 func newRunConfig(schedule bool, newsAPI string) runConfig {
-	cfg := runConfig{ //nolint:exhaustruct // newChapterTracker and injectChapters set conditionally below
-		schedule:     schedule,
-		tickInterval: 5 * time.Second, //nolint:mnd
-		nowFn:        time.Now,
+	cfg := runConfig{ //nolint:exhaustruct // newChapterTracker set conditionally below
+		schedule:       schedule,
+		tickInterval:   5 * time.Second, //nolint:mnd
+		nowFn:          time.Now,
+		injectMetadata: defaultInjectMetadata,
 	}
 	if newsAPI != "" {
 		slog.Info("Chapter tracking enabled", slog.String("news_api", newsAPI))
 		cfg.newChapterTracker = func() chapterProvider {
 			nc := chapters.NewNewsClient(http.DefaultClient, newsAPI)
-			return chapters.NewChapterTracker(nc, time.Now)
+			return chapters.NewChapterTracker(nc, time.Now, showHour)
 		}
-		cfg.injectChapters = chapters.InjectChapters
+		cfg.injectMetadata = func(filePath string, duration time.Duration, tracker chapterProvider) error {
+			return injectPostRecordingMetadata(filePath, duration, tracker, chapters.BuildChapterFrames) //nolint:wrapcheck // thin wrapper
+		}
 	}
 	return cfg
 }
@@ -317,11 +322,14 @@ func makeScheduleStatusFn(schedule bool) func() server.ScheduleStatus {
 		if !inScheduleWindow(now) {
 			return server.ScheduleStatus{} //nolint:exhaustruct // zero value means outside window
 		}
+		ttShow := timeToShow(now)
 		status := "show in progress"
-		if ttShow := timeToShow(now); ttShow > 0 {
+		showMin := 0
+		if ttShow > 0 {
+			showMin = int(ttShow.Minutes())
 			status = fmtDuration(ttShow) + " to show"
 		}
-		return server.ScheduleStatus{InWindow: true, ShowStatus: status}
+		return server.ScheduleStatus{InWindow: true, ShowStatus: status, ShowMinutes: showMin}
 	}
 }
 
@@ -451,17 +459,19 @@ func recordStream(ctx context.Context, r streamRecorder, stream *recorder.Stream
 		if ctx.Err() != nil {
 			logRecordingFinished("recording stopped", stream.Number, filePath, duration)
 			if filePath != "" {
-				maybeInjectChapters(tracker, filePath, cfg.injectChapters)
+				tryInjectMetadata(cfg, filePath, duration, tracker)
 			}
 			return stopLoop // clean shutdown
 		}
 		slog.Error("error while recording", slog.String("err", err.Error()))
-		slog.Info("stream lost, waiting for reconnect", slog.String("episode", stream.Number))
+		if strings.Contains(err.Error(), "failed to read from stream") {
+			slog.Info("stream lost, waiting for reconnect", slog.String("episode", stream.Number))
+		}
 		return continueLoop
 	}
 
 	logRecordingFinished("finished recording", stream.Number, filePath, duration)
-	maybeInjectChapters(tracker, filePath, cfg.injectChapters)
+	tryInjectMetadata(cfg, filePath, duration, tracker)
 	return continueLoop
 }
 
@@ -476,19 +486,35 @@ func logRecordingFinished(msg, episode, filePath string, duration time.Duration)
 	slog.Info(msg, attrs...)
 }
 
-// maybeInjectChapters injects collected chapter markers into the recorded file.
-// does nothing when tracker is nil or no chapters were collected.
-func maybeInjectChapters(tracker chapterProvider, filePath string, inject func(string, []chapters.Chapter) error) {
-	if tracker == nil || inject == nil {
+// tryInjectMetadata calls the configured metadata injector if set.
+func tryInjectMetadata(cfg runConfig, filePath string, duration time.Duration, tracker chapterProvider) {
+	if cfg.injectMetadata == nil {
 		return
 	}
-	chaps := tracker.Chapters()
-	if len(chaps) == 0 {
-		return
+	if err := cfg.injectMetadata(filePath, duration, tracker); err != nil {
+		slog.Error("failed to inject metadata", slog.String("err", err.Error()))
 	}
-	if err := inject(filePath, chaps); err != nil {
-		slog.Error("failed to inject chapters", slog.String("err", err.Error()))
-	} else {
-		slog.Info("injected chapter markers", slog.Int("count", len(chaps)))
+}
+
+// defaultInjectMetadata is the default metadata injector (TLEN only, no chapters).
+func defaultInjectMetadata(filePath string, duration time.Duration, tracker chapterProvider) error {
+	return injectPostRecordingMetadata(filePath, duration, tracker, nil) //nolint:wrapcheck // thin wrapper
+}
+
+// injectPostRecordingMetadata writes TLEN and chapter markers into the recorded file
+// in a single file rewrite pass.
+func injectPostRecordingMetadata(filePath string, duration time.Duration,
+	tracker chapterProvider, buildChapFrames func([]chapters.Chapter) []byte) error {
+	// build TLEN frame
+	frames := recorder.TLENFrame(duration)
+
+	// build chapter frames if available
+	if tracker != nil && buildChapFrames != nil {
+		if chaps := tracker.Chapters(); len(chaps) > 0 {
+			frames = append(frames, buildChapFrames(chaps)...)
+			slog.Info("injected chapter markers", slog.Int("count", len(chaps)))
+		}
 	}
+
+	return id3.InjectFrames(filePath, frames)
 }

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -59,7 +59,7 @@ func siteAPIMock() *httpClientMock {
 			if req.URL.Path == "/site-api/last/1" {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`[{"title": "Radio-T 999"}]`)),
+					Body:       io.NopCloser(strings.NewReader(`[{"title": "Radio-T 998"}]`)),
 				}, nil
 			}
 			return http.DefaultClient.Do(req) //nolint:gosec,nolintlint // test mock proxies to real client
@@ -112,7 +112,7 @@ func TestFullPipeline(t *testing.T) {
 	episodeDirs, err := os.ReadDir(recordsPath)
 	require.NoError(t, err)
 	require.Len(t, episodeDirs, 1)
-	assert.Equal(t, "999", episodeDirs[0].Name(), "episode directory should be named after episode number")
+	assert.Equal(t, "999", episodeDirs[0].Name(), "episode directory should be named after next episode number")
 
 	// verify recording file created with correct naming pattern
 	episodePath := filepath.Join(recordsPath, "999")

--- a/app/recorder/id3.go
+++ b/app/recorder/id3.go
@@ -1,42 +1,25 @@
 package recorder
 
 import (
-	"io"
+	"strconv"
 	"time"
+
+	"github.com/radio-t/stream-recorder/app/id3"
 )
 
-// WriteID3v2Header writes a minimal ID3v2.4 header with title, artist and recording date.
-func WriteID3v2Header(w io.Writer, episode string, recorded time.Time) error {
-	frames := id3TextFrame("TIT2", "Radio-T "+episode)
-	frames = append(frames, id3TextFrame("TPE1", "Radio-T")...)
-	frames = append(frames, id3TextFrame("TDRC", recorded.Format("2006-01-02 15:04"))...)
-
-	// ID3v2.4 header: "ID3" + version 2.4 + no flags + syncsafe size
-	header := []byte{'I', 'D', '3', 4, 0, 0, 0, 0, 0, 0}
-	putSyncsafe(header[6:10], len(frames))
-
-	if _, err := w.Write(header); err != nil {
-		return err
-	}
-	_, err := w.Write(frames)
-	return err
+// WriteID3v2Header writes an ID3v2.4 header with title, artist, recording date and podcast metadata.
+func WriteID3v2Header(w interface{ Write([]byte) (int, error) }, episode string, recorded time.Time) error {
+	frames := id3.TextFrame("TIT2", "Radio-T "+episode)
+	frames = append(frames, id3.TextFrame("TPE1", "Radio-T")...)
+	frames = append(frames, id3.TextFrame("TALB", "Radio-T")...)
+	frames = append(frames, id3.TextFrame("TRCK", episode)...)
+	frames = append(frames, id3.TextFrame("TCON", "Podcast")...)
+	frames = append(frames, id3.TextFrame("TCOP", "Some rights reserved, Radio-T")...)
+	frames = append(frames, id3.TextFrame("TDRC", recorded.Format("2006-01-02 15:04"))...)
+	return id3.WriteHeader(w, frames)
 }
 
-// id3TextFrame builds an ID3v2.4 text frame (UTF-8 encoding).
-func id3TextFrame(id, text string) []byte {
-	data := append([]byte{3}, []byte(text)...) // 0x03 = UTF-8 encoding
-	frame := make([]byte, 10+len(data))
-	copy(frame[0:4], id)
-	putSyncsafe(frame[4:8], len(data))
-	// frame[8:10] = flags, left as 0x0000
-	copy(frame[10:], data)
-	return frame
-}
-
-// putSyncsafe encodes size as a 4-byte syncsafe integer (7 bits per byte).
-func putSyncsafe(dst []byte, size int) {
-	dst[0] = byte(size>>21) & 0x7f //nolint:gosec
-	dst[1] = byte(size>>14) & 0x7f //nolint:gosec
-	dst[2] = byte(size>>7) & 0x7f  //nolint:gosec
-	dst[3] = byte(size) & 0x7f     //nolint:gosec
+// TLENFrame builds a TLEN (track length in milliseconds) ID3v2 text frame.
+func TLENFrame(duration time.Duration) []byte {
+	return id3.TextFrame("TLEN", strconv.FormatInt(duration.Milliseconds(), 10))
 }

--- a/app/recorder/id3_test.go
+++ b/app/recorder/id3_test.go
@@ -1,4 +1,4 @@
-package recorder
+package recorder_test
 
 import (
 	"bytes"
@@ -7,12 +7,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/radio-t/stream-recorder/app/id3"
+	"github.com/radio-t/stream-recorder/app/recorder"
 )
 
 func TestWriteID3v2Header(t *testing.T) {
 	var buf bytes.Buffer
 	ts := time.Date(2026, 3, 27, 10, 30, 0, 0, time.UTC)
-	require.NoError(t, WriteID3v2Header(&buf, "999", ts))
+	require.NoError(t, recorder.WriteID3v2Header(&buf, "999", ts))
 
 	data := buf.Bytes()
 
@@ -22,50 +25,38 @@ func TestWriteID3v2Header(t *testing.T) {
 	assert.Equal(t, byte(0), data[4], "minor version should be 0")
 
 	// decode syncsafe size and verify it matches remaining bytes
-	size := int(data[6])<<21 | int(data[7])<<14 | int(data[8])<<7 | int(data[9])
+	size := id3.ReadSyncsafe(data[6:10])
 	assert.Equal(t, len(data)-10, size, "syncsafe size should match frame data length")
 
 	// parse frames from the body
 	frames := data[10:]
 	found := map[string]string{}
 	for len(frames) >= 10 {
-		id := string(frames[0:4])
-		sz := readSyncsafe(frames[4:8])
+		frameID := string(frames[0:4])
+		sz := id3.ReadSyncsafe(frames[4:8])
 		if sz == 0 || 10+sz > len(frames) {
 			break
 		}
 		// skip 2-byte flags and 1-byte encoding prefix
 		text := string(frames[11 : 10+sz])
-		found[id] = text
+		found[frameID] = text
 		frames = frames[10+sz:]
 	}
 
 	assert.Equal(t, "Radio-T 999", found["TIT2"], "title should contain episode number")
 	assert.Equal(t, "Radio-T", found["TPE1"], "artist should be Radio-T")
+	assert.Equal(t, "Radio-T", found["TALB"], "album should be Radio-T")
+	assert.Equal(t, "999", found["TRCK"], "track number should be episode number")
+	assert.Equal(t, "Podcast", found["TCON"], "genre should be Podcast")
+	assert.Equal(t, "Some rights reserved, Radio-T", found["TCOP"], "copyright should be set")
 	assert.Equal(t, "2026-03-27 10:30", found["TDRC"], "recording date should be formatted")
 }
 
-func TestPutSyncsafe(t *testing.T) {
-	tests := []struct {
-		name string
-		val  int
-		want []byte
-	}{
-		{name: "zero", val: 0, want: []byte{0, 0, 0, 0}},
-		{name: "127", val: 127, want: []byte{0, 0, 0, 127}},
-		{name: "128", val: 128, want: []byte{0, 0, 1, 0}},
-		{name: "255", val: 255, want: []byte{0, 0, 1, 127}},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			dst := make([]byte, 4)
-			putSyncsafe(dst, tc.val)
-			assert.Equal(t, tc.want, dst)
-		})
-	}
-}
-
-// readSyncsafe is a test helper — decodes a 4-byte syncsafe integer for verification.
-func readSyncsafe(b []byte) int {
-	return int(b[0])<<21 | int(b[1])<<14 | int(b[2])<<7 | int(b[3])
+func TestTLENFrame(t *testing.T) {
+	frame := recorder.TLENFrame(2*time.Hour + 41*time.Minute + 30*time.Second)
+	assert.Equal(t, "TLEN", string(frame[0:4]))
+	sz := id3.ReadSyncsafe(frame[4:8])
+	// skip flags (2 bytes) + encoding byte (1 byte)
+	text := string(frame[11 : 10+sz])
+	assert.Equal(t, "9690000", text, "TLEN should be duration in milliseconds")
 }

--- a/app/recorder/listener.go
+++ b/app/recorder/listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
@@ -28,6 +29,8 @@ func NewListener(c StreamSource) *Listener {
 	}
 }
 
+// getStreamNumber extracts the episode number from the site API title and increments it.
+// the API returns the last published episode, but we're always recording the next one.
 func getStreamNumber(latest string) string {
 	args := strings.Fields(latest)
 	if len(args) < 2 { //nolint:mnd
@@ -37,7 +40,11 @@ func getStreamNumber(latest string) string {
 	if num == "" || num == "." || strings.Contains(num, "..") || strings.ContainsAny(num, "/\\") {
 		return "0"
 	}
-	return num
+	n, err := strconv.Atoi(num)
+	if err != nil {
+		return num
+	}
+	return strconv.Itoa(n + 1)
 }
 
 // Stream represents a stream

--- a/app/recorder/listener_test.go
+++ b/app/recorder/listener_test.go
@@ -96,7 +96,7 @@ func TestNewStreamSanitisesNumber(t *testing.T) {
 		title    string
 		expected string
 	}{
-		{name: "normal episode", title: "Radio-T 999", expected: "999"},
+		{name: "normal episode increments by 1", title: "Radio-T 998", expected: "999"},
 		{name: "single word returns 0", title: "Radio-T", expected: "0"},
 		{name: "empty string returns 0", title: "", expected: "0"},
 		{name: "path traversal returns 0", title: "Radio-T ../../../etc", expected: "0"},
@@ -104,7 +104,7 @@ func TestNewStreamSanitisesNumber(t *testing.T) {
 		{name: "backslash in number returns 0", title: "Radio-T foo\\bar", expected: "0"},
 		{name: "dots in number returns 0", title: "Radio-T ..", expected: "0"},
 		{name: "single dot returns 0", title: "Radio-T .", expected: "0"},
-		{name: "double space handled", title: "Radio-T  999", expected: "999"},
+		{name: "double space handled", title: "Radio-T  998", expected: "999"},
 	}
 
 	for _, tc := range tests {

--- a/app/recorder/recorder_test.go
+++ b/app/recorder/recorder_test.go
@@ -105,7 +105,7 @@ func TestRecorderContextCancellation(t *testing.T) {
 	r := recorder.NewRecorder(dir, nil)
 
 	sr := newSlowReader()
-	s := recorder.NewStream("rt 999", sr)
+	s := recorder.NewStream("rt 998", sr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -202,7 +202,7 @@ func TestRecorderContextAlreadyCancelled(t *testing.T) {
 	r := recorder.NewRecorder(dir, nil)
 
 	sr := newSlowReader()
-	s := recorder.NewStream("rt 888", sr)
+	s := recorder.NewStream("rt 887", sr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before Record starts

--- a/app/run_test.go
+++ b/app/run_test.go
@@ -265,7 +265,6 @@ func TestPollAndRecord_WithChapterTracking(t *testing.T) {
 	}
 
 	var injectedPath string
-	var injectedChaps []chapters.Chapter
 
 	ml := &mockStreamListener{
 		listenFn: func(_ context.Context) (*recorder.Stream, error) {
@@ -285,9 +284,9 @@ func TestPollAndRecord_WithChapterTracking(t *testing.T) {
 		newChapterTracker: func() chapterProvider {
 			return tracker
 		},
-		injectChapters: func(path string, chs []chapters.Chapter) error {
-			injectedPath = path
-			injectedChaps = chs
+		injectMetadata: func(fp string, _ time.Duration, tp chapterProvider) error {
+			injectedPath = fp
+			assert.Equal(t, chaps, tp.Chapters(), "tracker should have collected chapters")
 			return nil
 		},
 	}
@@ -296,8 +295,7 @@ func TestPollAndRecord_WithChapterTracking(t *testing.T) {
 	action := pollAndRecord(ctx, ml, mr, cfg, &recordingState{})
 
 	assert.Equal(t, continueLoop, action)
-	assert.Equal(t, testRecordedPath, injectedPath, "chapters should be injected into recorded file")
-	assert.Equal(t, chaps, injectedChaps, "all collected chapters should be passed to injection")
+	assert.Equal(t, testRecordedPath, injectedPath, "metadata should be injected into recorded file")
 }
 
 func TestPollAndRecord_ChapterTrackingDisabled(t *testing.T) {
@@ -333,7 +331,7 @@ func TestPollAndRecord_NoChaptersCollected(t *testing.T) {
 		chapters:  nil, // no chapters collected
 	}
 
-	var injectionCalled bool
+	var metadataInjected bool
 
 	ml := &mockStreamListener{
 		listenFn: func(_ context.Context) (*recorder.Stream, error) {
@@ -353,8 +351,9 @@ func TestPollAndRecord_NoChaptersCollected(t *testing.T) {
 		newChapterTracker: func() chapterProvider {
 			return tracker
 		},
-		injectChapters: func(_ string, _ []chapters.Chapter) error {
-			injectionCalled = true
+		injectMetadata: func(_ string, _ time.Duration, tp chapterProvider) error {
+			metadataInjected = true
+			assert.Empty(t, tp.Chapters(), "tracker should have no chapters")
 			return nil
 		},
 	}
@@ -362,7 +361,7 @@ func TestPollAndRecord_NoChaptersCollected(t *testing.T) {
 	ctx := context.Background()
 	pollAndRecord(ctx, ml, mr, cfg, &recordingState{})
 
-	assert.False(t, injectionCalled, "injection should not be called when no chapters collected")
+	assert.True(t, metadataInjected, "metadata injection should be called for TLEN even without chapters")
 }
 
 func TestPollAndRecord_ChapterTrackingRecordingFails(t *testing.T) {
@@ -391,7 +390,7 @@ func TestPollAndRecord_ChapterTrackingRecordingFails(t *testing.T) {
 		newChapterTracker: func() chapterProvider {
 			return tracker
 		},
-		injectChapters: func(_ string, _ []chapters.Chapter) error {
+		injectMetadata: func(_ string, _ time.Duration, _ chapterProvider) error {
 			injectionCalled = true
 			return nil
 		},
@@ -428,7 +427,7 @@ func TestPollAndRecord_ChapterInjectionError(t *testing.T) {
 		newChapterTracker: func() chapterProvider {
 			return tracker
 		},
-		injectChapters: func(_ string, _ []chapters.Chapter) error {
+		injectMetadata: func(_ string, _ time.Duration, _ chapterProvider) error {
 			return fmt.Errorf("injection failed")
 		},
 	}
@@ -453,7 +452,6 @@ func TestPollAndRecord_ChapterInjectionOnContextCancel(t *testing.T) {
 	}
 
 	var injectedPath string
-	var injectedChaps []chapters.Chapter
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -476,9 +474,9 @@ func TestPollAndRecord_ChapterInjectionOnContextCancel(t *testing.T) {
 		newChapterTracker: func() chapterProvider {
 			return tracker
 		},
-		injectChapters: func(path string, chs []chapters.Chapter) error {
-			injectedPath = path
-			injectedChaps = chs
+		injectMetadata: func(fp string, _ time.Duration, tp chapterProvider) error {
+			injectedPath = fp
+			assert.Equal(t, chaps, tp.Chapters(), "tracker should have collected chapters")
 			return nil
 		},
 	}
@@ -486,8 +484,7 @@ func TestPollAndRecord_ChapterInjectionOnContextCancel(t *testing.T) {
 	action := pollAndRecord(ctx, ml, mr, cfg, &recordingState{})
 
 	assert.Equal(t, stopLoop, action, "should signal clean shutdown")
-	assert.Equal(t, testRecordedPath, injectedPath, "chapters should be injected even on context cancellation")
-	assert.Equal(t, chaps, injectedChaps, "all collected chapters should be passed to injection")
+	assert.Equal(t, testRecordedPath, injectedPath, "metadata should be injected even on context cancellation")
 }
 
 func TestInScheduleWindow(t *testing.T) {
@@ -730,7 +727,7 @@ func TestRun_ChapterTrackingPerRecording(t *testing.T) {
 				chapters:  nil,
 			}
 		},
-		injectChapters: func(_ string, _ []chapters.Chapter) error {
+		injectMetadata: func(_ string, _ time.Duration, _ chapterProvider) error {
 			return nil
 		},
 	}

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -25,21 +25,31 @@ import (
 	"github.com/didip/tollbooth/v8/limiter"
 	"github.com/go-pkgz/routegroup"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/radio-t/stream-recorder/app/id3"
 )
 
 //go:embed static/index.html
 var indexTemplateFS embed.FS
 
+// fileInfo represents a single recording file with its metadata.
+type fileInfo struct {
+	Name     string
+	Size     string // human-readable file size
+	Duration string // estimated duration from file size at 128kbps
+}
+
 // episode represents a recorded episode directory with its files
 type episode struct {
 	Name  string
-	Files []string
+	Files []fileInfo
 }
 
 // ScheduleStatus represents the current state of the recording window.
 type ScheduleStatus struct {
-	InWindow   bool
-	ShowStatus string // e.g. "32m to show" or "show in progress"
+	InWindow    bool
+	ShowStatus  string // e.g. "32m to show" or "show in progress"
+	ShowMinutes int    // minutes until show start, 0 when show is in progress or outside window
 }
 
 // Server is the main struct for the server
@@ -147,14 +157,26 @@ func listEpisodes(dir string) ([]episode, error) { //nolint:gocyclo // flat stru
 		if err != nil {
 			return nil, fmt.Errorf("reading episode dir: %w", err)
 		}
-		var fileNames []string
+		var fileInfos []fileInfo
 		for _, f := range files {
 			if strings.HasSuffix(f.Name(), ".tmp") {
 				continue // skip transient temp files (e.g. chapter injection)
 			}
-			fileNames = append(fileNames, f.Name())
+			var size string
+			var duration string
+			if info, infoErr := f.Info(); infoErr == nil {
+				sz := info.Size()
+				size = fmtBytes(sz)
+				filePath := filepath.Join(dir, d.Name(), f.Name())
+				if tlen := id3.ReadTLEN(filePath); tlen > 0 {
+					duration = fmtDurationSecs(tlen)
+				} else {
+					duration = estimateDuration(sz)
+				}
+			}
+			fileInfos = append(fileInfos, fileInfo{Name: f.Name(), Size: size, Duration: duration})
 		}
-		episodes = append(episodes, episode{Name: d.Name(), Files: fileNames})
+		episodes = append(episodes, episode{Name: d.Name(), Files: fileInfos})
 	}
 
 	// sort episodes numerically so "1000" comes after "999"
@@ -189,7 +211,7 @@ func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		last := episodes[len(episodes)-1]
 		activeEpisode = last.Name
 		if len(last.Files) > 0 {
-			activeFile = last.Name + "/" + last.Files[len(last.Files)-1]
+			activeFile = last.Name + "/" + last.Files[len(last.Files)-1].Name
 		}
 	}
 
@@ -208,6 +230,7 @@ func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		AuthEnabled     bool
 		InWindow        bool
 		ShowStatus      string
+		ShowMinutes     int
 	}{
 		Episodes:        episodes,
 		ShowForceRecord: s.forceRecord != nil,
@@ -218,6 +241,7 @@ func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 		AuthEnabled:     s.authPasswd != "",
 		InWindow:        schedStatus.InWindow,
 		ShowStatus:      schedStatus.ShowStatus,
+		ShowMinutes:     schedStatus.ShowMinutes,
 	}
 
 	var buf bytes.Buffer
@@ -315,6 +339,41 @@ func getCapacity(dir string) (int, error) {
 	return capacity, nil
 }
 
+// fmtBytes formats a byte count as a human-readable string.
+func fmtBytes(b int64) string {
+	const (
+		mb = 1024 * 1024
+		gb = 1024 * 1024 * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1fGB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1fMB", float64(b)/float64(mb))
+	default:
+		return fmt.Sprintf("%dKB", b/1024) //nolint:mnd
+	}
+}
+
+// fmtDurationSecs formats seconds as a human-readable duration string.
+func fmtDurationSecs(secs int64) string {
+	h := secs / 3600        //nolint:mnd
+	m := (secs % 3600) / 60 //nolint:mnd
+	if h > 0 {
+		return fmt.Sprintf("%dh%02dm", h, m)
+	}
+	if m == 0 {
+		return fmt.Sprintf("%ds", secs)
+	}
+	return fmt.Sprintf("%dm", m)
+}
+
+// estimateDuration estimates audio duration from file size assuming 128kbps bitrate.
+func estimateDuration(size int64) string {
+	const bitrate = 128 * 1024 / 8 // 128kbps in bytes per second
+	return fmtDurationSecs(size / int64(bitrate))
+}
+
 // validPathSegment returns true if the segment is safe to use in a file path.
 func validPathSegment(s string) bool {
 	return s != "" && s != "." && !strings.Contains(s, "..") && !strings.Contains(s, "/")
@@ -408,7 +467,7 @@ func (s *Server) activeFileInfo() (episodeName, filePath string) {
 	if len(last.Files) == 0 {
 		return "", ""
 	}
-	return last.Name, filepath.Join(s.dir, last.Name, last.Files[len(last.Files)-1])
+	return last.Name, filepath.Join(s.dir, last.Name, last.Files[len(last.Files)-1].Name)
 }
 
 // tailFile reads from f and writes to w, waiting for more data when EOF is reached

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -206,7 +206,7 @@ func TestIndexHandler(t *testing.T) {
 	t.Run("shows schedule badge when in window", func(t *testing.T) {
 		dir := setupTestDir(t)
 		srv := NewServer("0", dir, "", nil, nil, func() ScheduleStatus {
-			return ScheduleStatus{InWindow: true, ShowStatus: "32m to show"}
+			return ScheduleStatus{InWindow: true, ShowStatus: "32m to show", ShowMinutes: 32}
 		})
 
 		req := newRequest(t, "/")
@@ -215,15 +215,30 @@ func TestIndexHandler(t *testing.T) {
 
 		body := rec.Body.String()
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Contains(t, body, "LIVE WINDOW")
+		assert.Contains(t, body, "window-badge")
 		assert.Contains(t, body, "32m to show")
-		assert.Contains(t, body, `content="60"`, "should auto-refresh every 60s when in window")
+	})
+
+	t.Run("shows show in progress badge", func(t *testing.T) {
+		dir := setupTestDir(t)
+		srv := NewServer("0", dir, "", nil, nil, func() ScheduleStatus {
+			return ScheduleStatus{InWindow: true, ShowStatus: "show in progress", ShowMinutes: 0}
+		})
+
+		req := newRequest(t, "/")
+		rec := httptest.NewRecorder()
+		srv.IndexHandler(rec, req)
+
+		body := rec.Body.String()
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, body, "show in progress")
+		assert.NotContains(t, body, "<script>", "no countdown script when show already started")
 	})
 
 	t.Run("hides schedule badge when outside window", func(t *testing.T) {
 		dir := setupTestDir(t)
 		srv := NewServer("0", dir, "", nil, nil, func() ScheduleStatus {
-			return ScheduleStatus{InWindow: false}
+			return ScheduleStatus{}
 		})
 
 		req := newRequest(t, "/")
@@ -232,7 +247,7 @@ func TestIndexHandler(t *testing.T) {
 
 		body := rec.Body.String()
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.NotContains(t, body, "LIVE WINDOW")
+		assert.NotContains(t, body, "window-badge")
 	})
 
 	t.Run("hides schedule badge when schedule disabled", func(t *testing.T) {
@@ -245,7 +260,7 @@ func TestIndexHandler(t *testing.T) {
 
 		body := rec.Body.String()
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.NotContains(t, body, "LIVE WINDOW")
+		assert.NotContains(t, body, "window-badge")
 	})
 }
 
@@ -779,7 +794,7 @@ func TestListEpisodes(t *testing.T) {
 				require.NoError(t, os.WriteFile(filepath.Join(epDir, "a.mp3"), []byte("data"), 0o600))
 				return dir
 			},
-			expected: []episode{{Name: "999", Files: []string{"a.mp3"}}},
+			expected: []episode{{Name: "999", Files: []fileInfo{{Name: "a.mp3", Size: "0KB", Duration: "0s"}}}},
 		},
 		{
 			name: "skips regular files in root",
@@ -792,7 +807,7 @@ func TestListEpisodes(t *testing.T) {
 				require.NoError(t, os.WriteFile(filepath.Join(epDir, "a.mp3"), []byte("data"), 0o600))
 				return dir
 			},
-			expected: []episode{{Name: "999", Files: []string{"a.mp3"}}},
+			expected: []episode{{Name: "999", Files: []fileInfo{{Name: "a.mp3", Size: "0KB", Duration: "0s"}}}},
 		},
 		{
 			name: "empty directory returns empty slice",

--- a/app/server/static/index.html
+++ b/app/server/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {{if or .Recording .RecordRequested}}<meta http-equiv="refresh" content="5">{{else if .InWindow}}<meta http-equiv="refresh" content="60">{{end}}
+    {{if or .Recording .RecordRequested}}<meta http-equiv="refresh" content="5">{{end}}
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
@@ -12,7 +12,7 @@
   </head>
   <body>
     <main class="container" style="max-width:720px;margin:auto">
-      <h1>Stream Recorder{{if .InWindow}} <small><mark>LIVE WINDOW · {{.ShowStatus}}</mark></small>{{end}}</h1>
+      <h1>Stream Recorder{{if .InWindow}} <span id="window-badge" style="font-size:0.4em;vertical-align:middle;background:var(--pico-primary-background);color:var(--pico-primary-inverse);padding:0.2em 0.6em;border-radius:4px;white-space:nowrap">{{.ShowStatus}}</span>{{end}}</h1>
 
       {{if .ShowForceRecord}}
       {{if .Recording}}
@@ -50,16 +50,18 @@
               <td><a href="/episode/{{$ep}}">{{$ep}}</a></td>
               <td>
                 {{range .Files}}
-                  {{$key := printf "%s/%s" $ep .}}
+                  {{$key := printf "%s/%s" $ep .Name}}
                   {{if eq $key $active}}
                   <div aria-busy="true">
-                    <a href="/episode/{{$ep}}/{{.}}">{{.}}</a>
+                    <a href="/episode/{{$ep}}/{{.Name}}">{{.Name}}</a>
                     <small><ins>recording</ins></small>
+                    {{if .Size}}<small style="color:var(--pico-muted-color);margin-left:0.3em">{{.Size}}</small>{{end}}
                   </div>
                   {{else}}
                   <div>
-                    <a href="/episode/{{$ep}}/{{.}}?download" title="Download">&#x1F4BE;</a>
-                    <a href="/episode/{{$ep}}/{{.}}">{{.}}</a>
+                    <a href="/episode/{{$ep}}/{{.Name}}?download" title="Download">&#x1F4BE;</a>
+                    <a href="/episode/{{$ep}}/{{.Name}}">{{.Name}}</a>
+                    {{if .Size}}<small style="color:var(--pico-muted-color);margin-left:0.3em">{{.Size}}{{if .Duration}}, {{.Duration}}{{end}}</small>{{end}}
                   </div>
                   {{end}}
                 {{end}}
@@ -73,5 +75,22 @@
         </tbody>
       </table>
     </main>
+    {{if and .InWindow (gt .ShowMinutes 0)}}
+    <script>
+      (function() {
+        var left = {{.ShowMinutes}};
+        var badge = document.getElementById("window-badge");
+        if (!badge) return;
+        setInterval(function() {
+          left--;
+          if (left <= 0) { badge.textContent = "show in progress"; return; }
+          var h = Math.floor(left / 60);
+          var m = left % 60;
+          var t = h > 0 ? h + "h" + (m < 10 ? "0" : "") + m + "m" : m + "m";
+          badge.textContent = t + " to show";
+        }, 60000);
+      })();
+    </script>
+    {{end}}
   </body>
 </html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: streamrecorder
 
     ports:
-    - 8098:8080
+    - 8080:8080
 
     volumes:
     - ./records:/records
@@ -12,7 +12,7 @@ services:
     environment:
       - PORT=8080
       - DIR=/records
-      - DBG=true
+      #- DBG=true
       - TZ=UTC
       - SCHEDULE=true
       #- RETENTION_DAYS=30


### PR DESCRIPTION
## Summary
Follow-up to #23.

### Added
- Compact styled schedule badge with JS countdown updating every 60s
- File sizes and duration in episode listing (from TLEN metadata, fallback to bitrate estimate)
- Growing file size display for active recording
- Seconds display for sub-minute files
- Album, track number, genre, copyright and TLEN to ID3v2 metadata, matching official Radio-T podcast files
- TLEN (actual recording duration) written into ID3 header after recording finishes
- "Вступление" intro chapter when the active topic predates show start (20:00 UTC)
- Shared `app/id3` package for ID3v2 frame building and injection primitives

### Changed
- Episode number incremented by 1 — site API returns last published, we record the next one
- TLEN + chapter injection merged into a single file rewrite pass (was two)
- Show start hour passed as parameter to chapter tracker instead of being hardcoded in two places
- "stream lost, waiting for reconnect" log scoped to actual stream read errors only
- DBG disabled by default in docker-compose.yml

### Removed
- Duplicated ID3 helpers between `recorder` and `chapters` packages (moved to shared `app/id3`)

<img width="838" height="345" alt="image" src="https://github.com/user-attachments/assets/a88d3381-edac-4d01-8964-8aa26ffeb400" />