### PR TITLE
Add post-recording VBR header fix to recorded MP3s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ FROM umputun/baseimage:app-latest
 # enables automatic changelog generation by tools like Dependabot
 LABEL org.opencontainers.image.source="https://github.com/radio-t/stream-recorder"
 
+# ffmpeg is used post-recording to add a Xing/Info VBR header to the MP3 so
+# players show the correct duration; the recorder still works without it.
+RUN apk add --no-cache ffmpeg
+
 COPY --from=build /build/streamrecorder /srv/streamrecorder
 RUN chown -R app:app /srv
 

--- a/app/main.go
+++ b/app/main.go
@@ -123,6 +123,7 @@ type runConfig struct {
 	nowFn             func() time.Time
 	newChapterTracker func() chapterProvider                             // nil = chapter tracking disabled
 	injectMetadata    func(string, time.Duration, chapterProvider) error // post-recording metadata injection
+	fixVBRHeader      func(string) error                                 // post-recording VBR header fix
 }
 
 // recordingState holds mutable runtime state for the recording loop.
@@ -140,6 +141,7 @@ func newRunConfig(schedule bool, newsAPI string) runConfig {
 		tickInterval:   5 * time.Second, //nolint:mnd
 		nowFn:          time.Now,
 		injectMetadata: defaultInjectMetadata,
+		fixVBRHeader:   recorder.FixVBRHeader,
 	}
 	if newsAPI != "" {
 		slog.Info("Chapter tracking enabled", slog.String("news_api", newsAPI))
@@ -486,13 +488,18 @@ func logRecordingFinished(msg, episode, filePath string, duration time.Duration)
 	slog.Info(msg, attrs...)
 }
 
-// tryInjectMetadata calls the configured metadata injector if set.
+// tryInjectMetadata calls the configured metadata injector if set, then fixes
+// the VBR header so players show correct duration and seek positions.
 func tryInjectMetadata(cfg runConfig, filePath string, duration time.Duration, tracker chapterProvider) {
-	if cfg.injectMetadata == nil {
-		return
+	if cfg.injectMetadata != nil {
+		if err := cfg.injectMetadata(filePath, duration, tracker); err != nil {
+			slog.Error("failed to inject metadata", slog.String("err", err.Error()))
+		}
 	}
-	if err := cfg.injectMetadata(filePath, duration, tracker); err != nil {
-		slog.Error("failed to inject metadata", slog.String("err", err.Error()))
+	if cfg.fixVBRHeader != nil {
+		if err := cfg.fixVBRHeader(filePath); err != nil {
+			slog.Error("failed to fix VBR header", slog.String("err", err.Error()))
+		}
 	}
 }
 

--- a/app/recorder/vbrfix.go
+++ b/app/recorder/vbrfix.go
@@ -1,0 +1,36 @@
+package recorder
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const ffmpegBin = "ffmpeg"
+
+// FixVBRHeader remuxes the file with ffmpeg -c copy to add a Xing/Info VBR header
+// to the first audio frame. Without that header, players estimate duration from
+// the first frame's bitrate, which is wrong for variable-bitrate streams and
+// makes a 3h recording appear as 8h+ in Apple/Safari.
+//
+// Skips silently when ffmpeg is not on PATH so the binary still works in
+// environments without the dependency.
+func FixVBRHeader(filePath string) error {
+	bin, err := exec.LookPath(ffmpegBin)
+	if err != nil {
+		slog.Info("ffmpeg not found, skipping VBR header fix", slog.String("file", filePath))
+		return nil
+	}
+
+	tmpPath := filepath.Join(filepath.Dir(filePath), "."+filepath.Base(filePath)+".vbrfix.tmp")
+	cmd := exec.Command(bin, "-y", "-loglevel", "error", "-i", filePath, "-c", "copy", "-f", "mp3", tmpPath) //nolint:gosec,noctx // filePath is server-controlled; runs once at end of recording
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		os.Remove(tmpPath) //nolint:errcheck,gosec
+		return fmt.Errorf("ffmpeg remux failed: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return os.Rename(tmpPath, filePath)
+}

--- a/app/recorder/vbrfix_test.go
+++ b/app/recorder/vbrfix_test.go
@@ -1,0 +1,52 @@
+package recorder
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixVBRHeader_NoFFmpeg(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "audio.mp3")
+	original := []byte("untouched")
+	require.NoError(t, os.WriteFile(filePath, original, 0o600))
+
+	require.NoError(t, FixVBRHeader(filePath))
+
+	got, err := os.ReadFile(filePath) //nolint:gosec
+	require.NoError(t, err)
+	assert.Equal(t, original, got, "file should be unchanged when ffmpeg is missing")
+}
+
+func TestFixVBRHeader_WithFFmpeg(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "audio.mp3")
+	require.NoError(t, generateTestMP3(filePath))
+
+	require.NoError(t, FixVBRHeader(filePath))
+
+	data, err := os.ReadFile(filePath) //nolint:gosec
+	require.NoError(t, err)
+	hasXing := bytes.Contains(data, []byte("Xing")) || bytes.Contains(data, []byte("Info"))
+	assert.True(t, hasXing, "remuxed file should contain Xing/Info VBR header")
+}
+
+// generateTestMP3 produces a tiny silent MP3 via ffmpeg's lavfi anullsrc.
+func generateTestMP3(path string) error {
+	cmd := exec.Command("ffmpeg", "-y", "-loglevel", "error", //nolint:gosec,noctx // test helper, fixed args
+		"-f", "lavfi", "-i", "anullsrc=r=44100:cl=stereo", "-t", "0.5",
+		"-c:a", "libmp3lame", "-b:a", "128k", path)
+	return cmd.Run()
+}


### PR DESCRIPTION
## Problem

Recorded MP3s have variable bitrate (the icecast source mixes 32-128 kbps frames depending on speech vs silence) but no Xing/Info VBR header. Without that header, players estimate duration from the first frame's bitrate, which is wildly wrong.

Episode 1012 example: actual audio is 3h15m17s, but Apple/Safari shows 8:42:17 in the timeline and seeking past ~4h11m stalls the player because there's no real audio there.

| Field | Before | After |
|---|---|---|
| Apple/Safari duration | 8:42:17 | 3:15:16 |
| ffprobe duration | 33,629s (estimated) | 11,716s (frame-counted) |
| Xing header | none | present |
| Chapters | 3 | 3 (preserved) |
| File size | 141,659,672 | 141,659,719 (+47 B) |

## Fix

Added `recorder.FixVBRHeader()` which remuxes the file with `ffmpeg -c copy -f mp3` after chapter injection. ffmpeg writes a proper Xing header (frame-counted duration), preserves all ID3 tags including the CHAP/CTOC frames written by `InjectChapters`, and doesn't re-encode (~1s for a 140 MB file).

Wired into `recordStream` after `maybeInjectChapters` on both the clean-shutdown and normal paths. Configurable via `runConfig.fixVBRHeader` for testability, mirroring the `injectChapters` pattern.

The post-processor calls `exec.LookPath("ffmpeg")` and no-ops with an info log when ffmpeg isn't on PATH, so dev/test runs without the dependency still work.

## Docker

`apk add --no-cache ffmpeg` added to the runtime stage. Image size goes from 50 MB to 119 MB (+68 MB for ffmpeg + libs). I looked for lighter alpine packages that can write a Xing header without re-encoding (mp3val, vbrfix) but none are in the alpine repo.