### PR TITLE
Fix episode number in the live-test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class H(http.server.BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(json.dumps([{"title": "Podcast 999"}]).encode())
+        self.wfile.write(json.dumps([{"title": "Podcast 998"}]).encode())
     def log_message(self, *a): pass
 http.server.HTTPServer(("127.0.0.1", 9999), H).serve_forever()
 ' &
@@ -59,7 +59,7 @@ http.server.HTTPServer(("127.0.0.1", 9999), H).serve_forever()
   --dir ./records --port 8080 --dbg
 ```
 
-The mock API returns `[{"title": "Podcast 999"}]`, so recordings appear under `records/999/`. Open http://localhost:8080 to see the web UI.
+The mock API returns `[{"title": "Podcast 998"}]`, so recordings appear under `records/999/`. The site API reports the *last published* episode, while the recorder always captures the *next* one, so `getStreamNumber` increments the parsed number by one and the directory is one higher than the title. Open http://localhost:8080 to see the web UI.
 
 Some public Icecast streams suitable for testing:
 


### PR DESCRIPTION
The mock site API in the "Testing with a live stream" section returns `Podcast 999`, while the text below claims recordings appear under `records/999/`. They do not: `getStreamNumber` parses the number and returns `n + 1`, so that payload records into `records/1000/`.

The increment is deliberate, the site API reports the last *published* episode and the recorder always captures the next one, so the fix belongs in the example rather than in `listener.go`. The example now returns `Podcast 998`, and the paragraph explains the increment so nobody reads the offset as a bug later.

Documentation only, no code change.