### PR TITLE
Use the UTC calendar date for stale-topic detection

### DIFF
--- a/app/chapters/chapters.go
+++ b/app/chapters/chapters.go
@@ -95,14 +95,18 @@ func (ct *ChapterTracker) fetchInitialTopic(ctx context.Context, startTime time.
 }
 
 // isStaleTopicForShow checks if a topic was activated before the show started.
-// the show starts at showStartHour UTC on the same day as the recording.
+// the show starts at showStartHour UTC on the same UTC day as the recording start.
 // returns true if the topic predates the show start, meaning it's a leftover.
 func (ct *ChapterTracker) isStaleTopicForShow(activeTS, recordingStart time.Time) bool {
 	if activeTS.IsZero() {
 		return false // no timestamp available, assume topic is current
 	}
+	// the show hour is UTC, so the calendar date has to come from the UTC instant too:
+	// in a positive-offset zone a 23:30 UTC start is already the next local day and would
+	// otherwise build tomorrow's show start, marking every valid topic stale
+	startUTC := recordingStart.UTC()
 	showStart := time.Date(
-		recordingStart.Year(), recordingStart.Month(), recordingStart.Day(),
+		startUTC.Year(), startUTC.Month(), startUTC.Day(),
 		ct.showStartHour, 0, 0, 0, time.UTC)
 	return activeTS.Before(showStart)
 }

--- a/app/chapters/chapters_test.go
+++ b/app/chapters/chapters_test.go
@@ -378,3 +378,71 @@ func TestChapterTracker_ChaptersThreadSafe(t *testing.T) {
 	chapters := tracker.Chapters()
 	assert.Len(t, chapters, 100)
 }
+
+func TestChapterTracker_IsStaleTopicForShow(t *testing.T) {
+	t.Parallel()
+
+	// zones the recorder may run in when TZ is not forced to UTC
+	bst := time.FixedZone("BST", 1*60*60)
+	msk := time.FixedZone("MSK", 3*60*60)
+
+	showStart := time.Date(2026, 3, 28, 20, 0, 0, 0, time.UTC) // Saturday 20:00 UTC
+
+	tests := []struct {
+		name           string
+		activeTS       time.Time
+		recordingStart time.Time
+		want           bool
+	}{
+		{
+			name:           "zero timestamp is never stale",
+			activeTS:       time.Time{},
+			recordingStart: showStart.Add(30 * time.Minute),
+			want:           false,
+		},
+		{
+			name:           "activated an hour before the show",
+			activeTS:       showStart.Add(-time.Hour),
+			recordingStart: showStart.Add(30 * time.Minute),
+			want:           true,
+		},
+		{
+			name:           "activated during the show",
+			activeTS:       showStart.Add(15 * time.Minute),
+			recordingStart: showStart.Add(30 * time.Minute),
+			want:           false,
+		},
+		{
+			name:           "activated exactly at the show start",
+			activeTS:       showStart,
+			recordingStart: showStart.Add(30 * time.Minute),
+			want:           false,
+		},
+		{
+			name:           "late recording start, already next day in a +1 zone",
+			activeTS:       showStart.Add(15 * time.Minute),
+			recordingStart: showStart.Add(3*time.Hour + 30*time.Minute).In(bst), // Sun 00:30 BST
+			want:           false,
+		},
+		{
+			name:           "late recording start, already next day in a +3 zone",
+			activeTS:       showStart.Add(15 * time.Minute),
+			recordingStart: showStart.Add(3*time.Hour + 30*time.Minute).In(msk), // Sun 02:30 MSK
+			want:           false,
+		},
+		{
+			name:           "stale topic still detected in a +3 zone past local midnight",
+			activeTS:       showStart.Add(-time.Hour),
+			recordingStart: showStart.Add(3*time.Hour + 30*time.Minute).In(msk),
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tracker := NewChapterTracker(nil, time.Now, 20)
+			assert.Equal(t, tt.want, tracker.isStaleTopicForShow(tt.activeTS, tt.recordingStart))
+		})
+	}
+}


### PR DESCRIPTION
`isStaleTopicForShow` takes the year/month/day from `recordingStart` as they read in the process timezone, then pins them to `time.UTC`. When the local date runs ahead of the UTC one the resulting show start is a day late.

Concretely, a recording that starts at 23:30 UTC under BST is already Sunday locally, so the function builds Sunday 20:00 UTC instead of Saturday 20:00 UTC. A topic activated on Saturday at 20:15 UTC then compares as older than the show start, the first chapter is discarded and replaced by the `Вступление` placeholder, and its article link is lost.

`docker-compose.yml` sets `TZ=UTC`, which hides this. Native deployments and containers with an overridden timezone reproduce it.

The fix takes the calendar date from the UTC instant, so every timezone now behaves like the `TZ=UTC` deployment. Added a table-driven test covering both `+1` and `+3` offsets past local midnight, along with the ordinary same-day cases; both offset cases fail without the change.