### PR TITLE
Compile the revision into docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,19 +40,44 @@ jobs:
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: build and push master image
+    - name: build docker image
+      run: |
+        docker build -t stream-recorder:ci \
+          --build-arg GIT_BRANCH="${GIT_BRANCH}" \
+          --build-arg GITHUB_SHA="${GITHUB_SHA}" .
+      env:
+        GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+
+    - name: verify revision is embedded in the image
+      run: |
+        cid=$(docker run -d stream-recorder:ci --dir /tmp --news "" \
+          --site http://127.0.0.1:1 --stream http://127.0.0.1:1)
+        trap 'docker rm -f "$cid" > /dev/null 2>&1 || true' EXIT
+        logs=""
+        for _ in $(seq 30); do
+          logs=$(docker logs "$cid" 2>&1)
+          case "$logs" in *"Starting stream-recorder"*) break ;; esac
+          sleep 1
+        done
+        echo "$logs"
+        echo "$logs" | grep -q "revision=${GIT_BRANCH}-" || \
+          { echo "revision was not compiled into the binary"; exit 1; }
+      env:
+        GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+
+    - name: push master image
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
-        docker build -t radiot/stream-recorder:master .
+        docker tag stream-recorder:ci radiot/stream-recorder:master
         docker login --username ${{ secrets.DOCKERHUB_USER }} --password ${{ secrets.DOCKERHUB_PASSWD }}
         docker push radiot/stream-recorder:master
 
-    - name: build and push tagged image
+    - name: push tagged image
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       run: |
         GIT_TAG="${GITHUB_REF#refs/tags/}"
-        docker build -t radiot/stream-recorder:${GIT_TAG} .
+        docker tag stream-recorder:ci "radiot/stream-recorder:${GIT_TAG}"
+        docker tag stream-recorder:ci radiot/stream-recorder:latest
         docker login --username ${{ secrets.DOCKERHUB_USER }} --password ${{ secrets.DOCKERHUB_PASSWD }}
-        docker push radiot/stream-recorder:${GIT_TAG}
-        docker tag radiot/stream-recorder:${GIT_TAG} radiot/stream-recorder:latest
+        docker push "radiot/stream-recorder:${GIT_TAG}"
         docker push radiot/stream-recorder:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,11 @@ ARG GITHUB_SHA
 ADD . /build
 WORKDIR /build
 
-RUN version=${GIT_BRANCH}-${GITHUB_SHA:0:7}-$(date +%Y%m%dT%H:%M:%S)
-RUN echo "version=$version"
-RUN cd app && go build -o /build/streamrecorder -ldflags "-X main.revision=${version} -s -w"
+# one RUN: a shell variable does not survive into the next layer, so computing the version
+# separately from the build leaves the linker flag empty
+RUN version="${GIT_BRANCH}-$(echo "${GITHUB_SHA}" | cut -c1-7)-$(date +%Y%m%dT%H:%M:%S)" && \
+    echo "version=${version}" && \
+    cd app && go build -o /build/streamrecorder -ldflags "-X main.revision=${version} -s -w"
 
 FROM umputun/baseimage:app-latest
 


### PR DESCRIPTION
Every image built from this repository logs an empty revision at startup, so a running container cannot be mapped back to a commit.

The Dockerfile assigns `version` in one `RUN` and reads it from the next. Each `RUN` is a separate shell, so `${version}` is empty by the time it reaches `-X main.revision`. CI compounds it: neither `docker build` passed `GIT_BRANCH` or `GITHUB_SHA`, so both `ARG`s were empty anyway.

The version is now computed and used inside a single `RUN`, with `cut` instead of `${var:0:7}` so it does not depend on the shell supporting substring expansion.

CI builds the image once, with the ref and SHA passed as build args, and the master and tag steps tag and push that image instead of rebuilding it. `github.head_ref || github.ref_name` gives the source branch on a pull request, `master` on a master push and the tag name on a tag push. What gets published is unchanged: `:master` for master, the tag plus `:latest` for tags.

A smoke test between the build and the pushes starts the built image, polls for its startup line and fails the job if the revision is not there, so this cannot regress silently. Verified locally: the image logs `revision=test-branch-0123456-20260819T10:14:47` for the corresponding build args.

The image is now also built on pull requests, which is the cost of having the Dockerfile covered by CI at all.