### PR TITLE
Update CI actions to their current majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: set up go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: '1.24'
 


### PR DESCRIPTION
`actions/checkout` v6 to v7 and `actions/setup-go` v6 to v7. `golangci/golangci-lint-action` is already on the current major.

Neither major needs a configuration change here. Both are ESM and dependency migrations; checkout v7 additionally refuses to check out fork PR heads under `pull_request_target` and `workflow_run`, and this workflow uses `push` and `pull_request`.