### PR TITLE
Move golangci-lint to v2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.11
+        version: v2.12
 
     - name: install goveralls
       run: go install github.com/mattn/goveralls@latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,11 @@ linters:
       disabled-checks:
         - whyNoLint
 
+    goconst:
+      # goconst counts occurrences across the whole package, so a literal repeated in fixtures
+      # can trip a finding located in production code; a path exclusion cannot suppress that
+      ignore-tests: true
+
     gocyclo:
       min-complexity: 10
 

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -272,7 +272,7 @@ func (s *Server) checkAuth(r *http.Request) bool {
 	// check form value first (web UI)
 	if pwd := r.PostFormValue("password"); pwd != "" {
 		if err := bcrypt.CompareHashAndPassword([]byte(s.authPasswd), []byte(pwd)); err != nil {
-			slog.Warn("auth failed", slog.String("source", "form"), slog.String("err", err.Error())) //nolint:gosec // error from bcrypt is not user-controlled
+			slog.Warn("auth failed", slog.String("source", "form"), slog.String("err", err.Error()))
 			return false
 		}
 		return true
@@ -281,7 +281,7 @@ func (s *Server) checkAuth(r *http.Request) bool {
 	// check basic auth header (curl/API)
 	if _, pwd, ok := r.BasicAuth(); ok {
 		if err := bcrypt.CompareHashAndPassword([]byte(s.authPasswd), []byte(pwd)); err != nil {
-			slog.Warn("auth failed", slog.String("source", "basic-auth"), slog.String("err", err.Error())) //nolint:gosec // error from bcrypt is not user-controlled
+			slog.Warn("auth failed", slog.String("source", "basic-auth"), slog.String("err", err.Error()))
 			return false
 		}
 		return true
@@ -415,6 +415,7 @@ func (s *Server) DownloadFileHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Has("download") {
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", file))
 	}
+	//nolint:gosec // G703: both segments pass validPathSegment and the result passes isSubPath above
 	http.ServeFile(w, r, filePath)
 }
 


### PR DESCRIPTION
The bump surfaces three things, all triaged rather than switched off.

`gosec` gained **G703**, which flags `http.ServeFile` in `DownloadFileHandler` as path traversal. Both segments already pass `validPathSegment`, which rejects empty, `.`, and anything containing `..` or a separator, and the joined path then passes `isSubPath`. The taint analysis does not see either check, so the call carries a scoped directive naming both. Reaching outside the directory would need a symlink planted by someone who already has write access to the recordings tree.

`nolintlint` reports the two `//nolint:gosec` directives on the bcrypt failure logging as unused, since no gosec rule fires there any more. Removed. The bcrypt error does not carry the submitted password, so nothing is being hidden.

`goconst` now inspects test files and reports fixture strings: episode filenames, a password reused across table cases, a repeated base path. It is configured with `ignore-tests: true` rather than added to the `_test.go` path exclusion, because `goconst` counts occurrences across the whole package before reporting; a literal repeated in fixtures can therefore trip a finding located in production code, which a path exclusion cannot suppress.

`golangci-lint run` is clean at v2.12.2.

One thing worth knowing: v2.13.0 was released on 19.08.2026 and deprecates `exhaustruct` in favour of `exhaustruct_v5`, which this config would need migrating for. That is a separate change from this one, so this PR stays on v2.12.